### PR TITLE
Remove nonexistent coverlet.runsettings reference from pr.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -714,7 +714,6 @@ jobs:
                   --configuration Release `
                   --framework $fw `
                   --collect:"XPlat Code Coverage" `
-                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=normal"
               } else {
@@ -1063,7 +1062,6 @@ jobs:
                 --configuration Release \
                 --framework "$fw" \
                 --collect:"XPlat Code Coverage" \
-                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=normal" || exit 1
             done <<< "$frameworks"


### PR DESCRIPTION
## Summary
- Remove `--settings coverlet.runsettings` from Windows (pwsh) and macOS (bash) test steps in pr.yaml
- The repo-template sync (PR #107) introduced this flag but no `coverlet.runsettings` file exists, causing Stage 2 Windows tests to fail with "The Settings file could not be found"

## Test plan
- [ ] Verify Stage 2 Windows tests pass without the runsettings flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)