### PR TITLE
Replace noreply email with Security tab link in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,10 +64,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement by contacting the
-repository owner through their GitHub profile at
-[github.com/Chris-Wolfgang](https://github.com/Chris-Wolfgang) and clearly
-labeling the message as a Code of Conduct report.
+reported to the community leaders responsible for enforcement by
+[privately reporting through the repository's Security tab](../../security/advisories/new).
+Although this tab is labeled for security vulnerabilities, it provides
+a private channel suitable for sensitive reports including Code of Conduct violations.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,8 +64,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement via the
-[Security tab](https://github.com/Chris-Wolfgang/DateTime-Extensions/security) on this repository.
+reported to the community leaders responsible for enforcement by contacting the
+repository owner through their GitHub profile at
+[github.com/Chris-Wolfgang](https://github.com/Chris-Wolfgang) and clearly
+labeling the message as a Code of Conduct report.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,8 +64,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-210299580+Chris-Wolfgang@users.noreply.github.com.
+reported to the community leaders responsible for enforcement via the
+[Security tab](https://github.com/Chris-Wolfgang/DateTime-Extensions/security) on this repository.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary
- Replaced the GitHub noreply email address in CODE_OF_CONDUCT.md with a link to the repository's Security tab, since the noreply address may not receive inbound mail.

## Test plan
- [x] Verify the link points to the correct Security tab URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)