### PR TITLE
chore: sync canonical /docs reference set

### DIFF
--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -4,7 +4,7 @@ This repository uses `dotnet format` to enforce consistent C# code style.
 
 ## Prerequisites
 
-The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. For full multi-target formatting (including the `net10.0` target), install the .NET 10.0 SDK or later so all target frameworks can be evaluated. If you only have the .NET 8.0 SDK installed, you can still run formatting by restricting to the `net8.0` target, for example: `dotnet format --framework net8.0`.
+The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. Since this project requires .NET 8.0 SDK or later, you already have `dotnet format` available — no separate tool installation is needed.
 
 > **Note:** The standalone `dotnet-format` global tool was deprecated when `dotnet format` was integrated into the .NET 6 SDK in August 2021.
 
@@ -15,13 +15,13 @@ The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 
 Run the formatting script with PowerShell Core (`pwsh`) on any supported platform:
 
 ```powershell
-pwsh ./format.ps1
+.\scripts\format.ps1
 ```
 
 Or check without making changes:
 
 ```powershell
-pwsh ./format.ps1 -Check
+.\scripts\format.ps1 -Check
 ```
 
 ### Manual Formatting
@@ -30,25 +30,21 @@ pwsh ./format.ps1 -Check
 dotnet format
 ```
 
-### Check Formatting (like CI does)
+### Verify Without Modifying Files
 
 ```bash
 dotnet format --verify-no-changes
 ```
 
+This is useful as a pre-commit guard or in a CI step if the repo opts in to enforcing formatting at PR time. By default, the standard PR workflow does **not** run `dotnet format --verify-no-changes`; formatting is treated as a developer-side hygiene step driven by `.editorconfig` and IDE-on-save behavior.
+
 ## Configuration
 
-Code style rules are defined in `.editorconfig` at the repository root.
+Code style rules are defined in `.editorconfig` at the repository root. `.editorconfig` is the source of truth — anything in this document that conflicts with `.editorconfig` should be considered out of date.
 
-## CI/CD
+## Local Enforcement
 
-All pull requests are automatically checked for proper formatting. PRs with formatting issues will fail the build.
-
-### If CI Fails
-
-1. Run `pwsh ./format.ps1` locally
-2. Review the changes
-3. Commit and push the formatted code
+Code formatting is enforced locally via `.editorconfig` and `dotnet format`. Run the formatting script before submitting a PR. If the repo has opted into a CI formatting check, the PR workflow will fail on unformatted code; resolve by running `.\scripts\format.ps1` locally and pushing the resulting changes.
 
 ## IDE Integration
 
@@ -60,9 +56,10 @@ Most IDEs automatically read `.editorconfig`:
 
 ## Formatting Rules
 
-Key style rules:
-- **Indentation**: 4 spaces for C# (with `switch` case contents not additionally indented when inside a block, per `.editorconfig`), 2 for XML/JSON
-- **Braces**: Opening brace on new line
-- **Line endings**: LF (Unix style)
+Authoritative rules live in `.editorconfig` (and `.gitattributes` for line endings, which may override the `.editorconfig` defaults for specific file types — e.g. forcing CRLF on `*.ps1`). The list below is a quick orientation; check those files for the binding values:
+
+- **Indentation**: 4 spaces for C#, 2 for XML/JSON (per `.editorconfig`)
+- **Braces**: Opening brace on its own line
+- **Line endings**: LF for source/docs, with file-type overrides in `.gitattributes` (e.g. CRLF for `*.ps1`)
 - **Trailing whitespace**: Removed
 - **Using directives**: System namespaces first, sorted alphabetically

--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -1,6 +1,6 @@
 # Release Workflow Setup Guide
 
-This guide explains how to configure the repository after merging the updated `release.yaml` workflow.
+This guide explains how to configure a repository to use the standard `release.yaml` workflow. The same checklist applies whether you are bootstrapping a new repo from `repo-template` or auditing an existing one.
 
 ## Overview
 
@@ -11,9 +11,9 @@ The release workflow triggers when you **publish a GitHub Release** and implemen
 - ✅ Automatically publishes to NuGet.org after validation passes
 - ✅ Eliminates duplicate build work for faster releases
 
-## Required Post-Merge Configuration
+## Required Configuration
 
-After merging the updated release workflow, complete the following setup steps:
+Complete the following one-time setup so that the workflow can publish releases:
 
 ### Add NuGet API Key Secret
 
@@ -29,11 +29,11 @@ After merging the updated release workflow, complete the following setup steps:
 
 **What this does:** Allows the workflow to authenticate with NuGet.org and publish packages. The workflow validates this secret exists before attempting to publish.
 
-### Verify Branch Ruleset
+### Verify Branch Protection Rules
 
-**Location:** Settings → Rules → Rulesets → `main` branch ruleset
+**Location:** Settings → Branches → main (or Settings → Rules → Rulesets)
 
-> **Note:** By default, the template is configured for single developer repositories. The branch ruleset setup script (`scripts/Setup-BranchRuleset.ps1`) includes interactive prompts that allow you to choose between single-developer or multi-developer settings during execution. Simply run the script and select option [1] for single-developer mode (0 approvals) or option [2] for multi-developer mode (1+ approvals and code owner review required).
+> **Note:** Repos created from `repo-template` ship with `scripts/Setup-BranchRuleset.ps1`, which configures branch protection interactively (option `[1]` for single-developer mode, `[2]` for multi-developer mode). The script may not be present in older repos — if it is missing, configure the equivalent settings manually using the checklist below.
 
 Ensure the following settings are enabled:
 
@@ -46,9 +46,7 @@ Ensure the following settings are enabled:
     - "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     - "Stage 3: macOS Tests (.NET 6.0-10.0)"
     - "Security Scan (DevSkim)"
-- ✅ **CodeQL code scanning enforcement** (via `code_scanning` ruleset type, not status checks)
-  - Blocks merging on High+ severity findings
-  - Automatically skips when no supported languages are detected
+    - "Security Scan (CodeQL)"
 - ✅ **Require branches to be up to date before merging**
 - ✅ **Require conversation resolution before merging**
 - ✅ **Do not allow bypassing the above settings** (recommended, even for admins)
@@ -172,7 +170,7 @@ Before creating a production GitHub Release (e.g., `v1.0.0`):
 ┌─────────────────────────────────────────────────────────────┐
 │  Job 1: validate-release (Windows)                          │
 │  • Restore & Build                                          │
-│  • Test all frameworks (net5.0-10.0, net462-481)            │
+│  • Test all frameworks (net5.0-10.0, net462-481)           │
 │  • Collect coverage                                         │
 │  • Enforce 90% threshold                                    │
 │  • Upload coverage artifacts                                │

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -41,8 +41,11 @@ A malicious PR could modify these files to disable security checks.
 - `BannedSymbols.txt` - Banned API usage rules
 - `*.globalconfig` - Global analyzer configuration
 - `*.ruleset` - Code analysis rulesets
+- `.github/workflows/*.yml` and `.github/workflows/*.yaml` - Workflow definitions
 
-**Implementation** (added to all workflow jobs):
+In addition to the overwrite step, a separate "Detect protected configuration file changes" step in `pr.yaml` causes the PR to fail if any of these files differ from `main`, signalling that a maintainer must manually review the change. Dependabot is exempted (its bumps to `Directory.Build.props` are legitimate).
+
+**Implementation** (in jobs that consume project source — e.g. `detect-projects`, the test stages, and the security scans; *not* the `secrets-scan` job, which only fetches `.gitleaks.toml`):
 ```yaml
 - name: Fetch trusted configuration files from main branch
   run: |
@@ -75,7 +78,7 @@ All checkout steps include `persist-credentials: false` to prevent the checkout 
 
 ```yaml
 - name: Checkout code
-  uses: actions/checkout@v4
+  uses: actions/checkout@v6
   with:
     ref: refs/pull/${{ github.event.pull_request.number }}/head
     persist-credentials: false
@@ -104,7 +107,7 @@ This limits the impact if the `GITHUB_TOKEN` is somehow exposed or misused.
 ### Scenario 2: Configuration File Tampering
 **Attack**: PR modifies `.editorconfig` to disable security analyzers
 **Prevention**: Configuration files are fetched from main branch after checkout
-**Status**: ✅ Protected (as of this PR)
+**Status**: ✅ Protected
 
 ### Scenario 3: Credential Theft
 **Attack**: PR contains malicious code that tries to access GitHub credentials
@@ -114,16 +117,14 @@ This limits the impact if the `GITHUB_TOKEN` is somehow exposed or misused.
 ### Scenario 4: Code Analysis Bypass
 **Attack**: PR modifies `BannedSymbols.txt` or `.ruleset` to allow dangerous APIs
 **Prevention**: These files are fetched from main branch after checkout
-**Status**: ✅ Protected (as of this PR)
+**Status**: ✅ Protected
 
-## Testing
+## Validation
 
-Security tests have been created and validated:
+The following manual validation scenarios can be used when reviewing changes to the workflow security model:
 
-1. **Configuration Fetch Test**: Verifies that configuration files can be successfully fetched from the main branch
-2. **Malicious Modification Test**: Simulates a PR that modifies `.editorconfig` to disable analyzers and confirms it's replaced with the trusted version
-
-Both tests pass successfully.
+1. **Configuration Fetch Validation**: Confirm that configuration files are fetched from the `main` branch during workflow execution
+2. **Malicious Modification Validation**: Simulate a PR that modifies `.editorconfig` to disable analyzers and confirm the workflow replaces it with the trusted version from `main`
 
 ## Maintenance
 
@@ -168,9 +169,10 @@ PR #2: New feature
 
 When adding new configuration files that control code quality or security:
 
-1. Add the file name to the `config_files` array in all workflow jobs (detect-projects, test-linux-core, test-windows, test-macos-core, security-scan)
-2. Test that the file is correctly fetched from main branch
-3. Update this documentation
+1. Add the file name to the `config_files` array in every job that runs `Fetch trusted configuration files from main branch` (the project-detection job, each test-stage job, and the security-scan jobs — search `pr.yaml` for that step name to find them all). The `secrets-scan` job does not consume project config files and does not need to be updated.
+2. Add the file path to the "Detect protected configuration file changes" guard in `pr.yaml` so PRs that touch the file fail with a maintainer-review banner.
+3. Test that the file is correctly fetched from main branch.
+4. Update this documentation.
 
 ## References
 


### PR DESCRIPTION
## Summary
Adds (or refreshes) the canonical `/docs` reference set from repo-template, polished in repo-template#338:

- `docs/README-FORMATTING.md`
- `docs/RELEASE-WORKFLOW-SETUP.md`
- `docs/WORKFLOW_SECURITY.md`

These are template-level reference docs maintained centrally and kept in sync across all .NET library repos.