### PR TITLE
C4: drop stale <AssemblyVersion> so versions stay in lock-step

### DIFF
--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -8,7 +8,9 @@
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
+		<!-- AssemblyVersion / FileVersion / InformationalVersion derive from
+		     <Version> automatically when not specified, so they stay in lock-step
+		     with the package version instead of going stale. -->
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary

The src csproj had `<AssemblyVersion>1.0.0</AssemblyVersion>` hardcoded — last touched at v1.0.0 and never bumped. Released packages from v1.1.0 onwards have shipped with AssemblyVersion=1.0.0 even though the package Version was 1.1.0/1.2.0.

Drop the explicit line. The .NET SDK derives AssemblyVersion, FileVersion, and InformationalVersion from `<Version>` automatically when they're not specified, so the four values stay in lock-step on every bump from this point forward.

## Test plan

- [x] `dotnet build -c Release` clean
- [ ] CI build verifies pack output's AssemblyVersion matches the package version

## Closes

#153

🤖 Generated with [Claude Code](https://claude.com/claude-code)