### PR TITLE
CI1: add RepositoryUrl + PackageTags to complete NuGet metadata

### DIFF
--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -8,7 +8,9 @@
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
+		<!-- AssemblyVersion / FileVersion / InformationalVersion derive from
+		     <Version> automatically when not specified, so they stay in lock-step
+		     with the package version instead of going stale. -->
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -7,6 +7,8 @@
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions.git</RepositoryUrl>
+		<PackageTags>dotnet;extensions;datetime;date;time;truncate;firstofmonth;endofmonth;firstofweek;endofweek;firstofyear;endofyear</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<!-- AssemblyVersion / FileVersion / InformationalVersion derive from
 		     <Version> automatically when not specified, so they stay in lock-step


### PR DESCRIPTION
## Summary

Adds the two per-repo NuGet metadata fields that the canonical comment in `Directory.Build.props` says "stays in each src csproj":

- `<RepositoryUrl>` — explicit GitHub HTTPS URL with `.git` suffix
- `<PackageTags>` — repo-specific search keywords for nuget.org discoverability

All other CI1 acceptance criteria (SourceLink, deterministic+CI builds, snupkg symbols, EmbedUntrackedSources, license + readme + icon + description) were already in `Directory.Build.props` from earlier CI3 / C13 work.

## Verification

`dotnet pack -c Release` produces a `.nuspec` with the new fields populated:

```xml
<projectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</projectUrl>
<description>A collection of extension methods for DateTime</description>
<tags>dotnet extensions datetime date time truncate firstofmonth endofmonth firstofweek endofweek firstofyear endofyear</tags>
<repository type="git" url="https://github.com/Chris-Wolfgang/DateTime-Extensions.git" branch="..." commit="..." />
```

`.snupkg` symbol package is also generated alongside the `.nupkg`.

## Stacked on

#184 (C4 version metadata) — base of this PR. Merge that first.

## Closes

#175

🤖 Generated with [Claude Code](https://claude.com/claude-code)