### PR TITLE
D2: seed CHANGELOG with v1.0.0–v1.2.0 history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [1.2.0] - 2026-04-27
+
+### Fixed
+
+- Boundary crashes in `FirstOfMonth`, `EndOfMonth`, `FirstOfYear`,
+  `EndOfYear`, `FirstOfWeek`, `EndOfWeek` near `DateTime.MaxValue` and
+  `DateTime.MinValue` — methods now return the boundary value instead of
+  throwing.
+- `FirstOfWeek` no longer carries the input's time-of-day into the
+  returned value (now consistently returns `00:00:00.0000000`).
+
+### Changed
+
+- Analyzer `PackageReference`s moved from `Directory.Build.props` into
+  individual csproj files, allowing per-project opt-out where required.
+
+## [1.1.0] - 2026-03-31
+
+### Changed
+
+- Dropped `netcoreapp3.1` target. Supported frameworks are now
+  `net462`, `netstandard2.0`, `net8.0`, and `net10.0`.
+
+### Fixed
+
+- `TruncateMilliseconds` and `TruncateSeconds` now use the 8-parameter
+  `DateTime` constructor with explicit `millisecond=0`, removing an
+  ambiguity that surfaced under some culture settings.
+- XML documentation corrections (`EndOfWeek` previously said "end of
+  the month").
+
+### Removed
+
+- `StyleCop.Analyzers` PackageReference removed in favour of the
+  consolidated analyzer set (Roslynator, Meziantou, SonarAnalyzer).
+
+## [1.0.0] - 2026-01-18
+
+### Added
+
+- Initial release with `TruncateMilliseconds`, `TruncateSeconds`,
+  `FirstOfMonth`, `EndOfMonth`, `FirstOfYear`, `EndOfYear`,
+  `FirstOfWeek`, `EndOfWeek` extension methods on `System.DateTime`.
+- Multi-framework targeting: `net462`, `netstandard2.0`,
+  `netcoreapp3.1`, `net8.0`, `net10.0`.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Analyzer `PackageReference`s consolidated back into `Directory.Build.props`
+  (reverses the v1.2.0 per-project split — see the v1.2.0 entry below). The
+  consolidated location is the single source of truth for the canonical
+  template-sync flow; per-project opt-out is still available via overrides
+  in a project's own csproj.
+
 ### Deprecated
 
 ### Removed
@@ -33,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Analyzer `PackageReference`s moved from `Directory.Build.props` into
-  individual csproj files, allowing per-project opt-out where required.
+  individual csproj files for this release (later reverted in
+  `[Unreleased]` — see above — when the canonical template-sync settled
+  on `Directory.Build.props` as the fleet-wide source of truth).
 
 ## [1.1.0] - 2026-03-31
 

--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -8,7 +8,9 @@
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
+		<!-- AssemblyVersion / FileVersion / InformationalVersion derive from
+		     <Version> automatically when not specified, so they stay in lock-step
+		     with the package version instead of going stale. -->
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -7,6 +7,8 @@
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions.git</RepositoryUrl>
+		<PackageTags>dotnet;extensions;datetime;date;time;truncate;firstofmonth;endofmonth;firstofweek;endofweek;firstofyear;endofyear</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<!-- AssemblyVersion / FileVersion / InformationalVersion derive from
 		     <Version> automatically when not specified, so they stay in lock-step


### PR DESCRIPTION
## Summary

CHANGELOG.md template existed but only had an empty `[Unreleased]` section. Seeded entries for the three released versions from git tag history (Keep a Changelog 1.1.0 conventions):

- **v1.2.0** (2026-04-27) — boundary-fix release + analyzer reshuffle
- **v1.1.0** (2026-03-31) — netcoreapp3.1 drop + Truncate* constructor fix
- **v1.0.0** (2026-01-18) — initial release

Added the standard footer link references so each section header anchors to the matching GitHub compare/tag view.

## Stacked on

#185 (CI1 NuGet metadata) — base of this PR.

## Closes

#164

🤖 Generated with [Claude Code](https://claude.com/claude-code)