### PR TITLE
P1: scaffold BenchmarkDotNet baseline project

### DIFF
--- a/DateTime-Extensions.slnx
+++ b/DateTime-Extensions.slnx
@@ -42,7 +42,9 @@
     <File Path="scripts/Setup-GitHubPages.ps1" />
     <File Path="scripts/setup.ps1" />
   </Folder>
-  <Folder Name="/benchmark/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Wolfgang.Extensions.DateTime.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/Wolfgang.Extensions.DateTime.DotNet462.Example1/Wolfgang.Extensions.DateTime.DotNet462.Example1.csproj" />
     <Project Path="examples/Wolfgang.Extensions.DateTime.DotNet80.Example1/Wolfgang.Extensions.DateTime.DotNet8.Example1.csproj" />

--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
@@ -1,0 +1,63 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.DateTime;
+
+namespace Wolfgang.Extensions.DateTime.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the public extension methods. All eight methods
+/// allocate a small number of DateTime structs and short loops; they should
+/// be well under a microsecond apiece. The MemoryDiagnoser is enabled so any
+/// future refactor that introduces allocation surfaces in the gh-pages
+/// benchmark chart immediately.
+/// </summary>
+[MemoryDiagnoser]
+public class DateTimeExtensionsBenchmarks
+{
+    // A representative mid-range UTC value — late enough that the MinValue
+    // boundary checks in FirstOfWeek do not short-circuit, but well clear of
+    // the MaxValue overflow guard so EndOfMonth / EndOfYear take the common
+    // fast path.
+    private static readonly System.DateTime Sample =
+        new(2026, 5, 26, 13, 45, 30, 123, DateTimeKind.Utc);
+
+
+
+    [Benchmark]
+    public System.DateTime TruncateMilliseconds() => Sample.TruncateMilliseconds();
+
+
+
+    [Benchmark]
+    public System.DateTime TruncateSeconds() => Sample.TruncateSeconds();
+
+
+
+    [Benchmark]
+    public System.DateTime FirstOfMonth() => Sample.FirstOfMonth();
+
+
+
+    [Benchmark]
+    public System.DateTime EndOfMonth() => Sample.EndOfMonth();
+
+
+
+    [Benchmark]
+    public System.DateTime FirstOfYear() => Sample.FirstOfYear();
+
+
+
+    [Benchmark]
+    public System.DateTime EndOfYear() => Sample.EndOfYear();
+
+
+
+    [Benchmark]
+    public System.DateTime FirstOfWeek_Sunday() => Sample.FirstOfWeek(DayOfWeek.Sunday);
+
+
+
+    [Benchmark]
+    public System.DateTime EndOfWeek_Sunday() => Sample.EndOfWeek(DayOfWeek.Sunday);
+}

--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
@@ -60,4 +60,18 @@ public class DateTimeExtensionsBenchmarks
 
     [Benchmark]
     public System.DateTime EndOfWeek_Sunday() => Sample.EndOfWeek(DayOfWeek.Sunday);
+
+
+
+    // The parameterless overloads add a `CultureInfo.CurrentCulture
+    // .DateTimeFormat.FirstDayOfWeek` lookup that the explicit-DayOfWeek
+    // overloads above don't exercise. Benchmark separately so a regression
+    // in the culture-lookup path is visible in its own chart series.
+    [Benchmark]
+    public System.DateTime FirstOfWeek_CurrentCulture() => Sample.FirstOfWeek();
+
+
+
+    [Benchmark]
+    public System.DateTime EndOfWeek_CurrentCulture() => Sample.EndOfWeek();
 }

--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Wolfgang.Extensions.DateTime.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Wolfgang.Extensions.DateTime.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.DateTime\Wolfgang.Extensions.DateTime.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
## Summary

Adds `benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/` following the **ETL-FixedWidth canonical pattern**:

- `net10.0`, `OutputType=Exe`, BenchmarkDotNet 0.15.8
- `BenchmarkSwitcher.FromAssembly(...)` entry point
- `[MemoryDiagnoser]` enabled
- One benchmark method per public API:
  `TruncateMilliseconds`, `TruncateSeconds`, `FirstOfMonth`, `EndOfMonth`, `FirstOfYear`, `EndOfYear`, `FirstOfWeek(Sunday)`, `EndOfWeek(Sunday)`

Wired into `DateTime-Extensions.slnx` under `/benchmarks/`.

## Verification

```
$ dotnet build -c Release
Build succeeded. 0 Warning(s) 0 Error(s)

$ ...exe --list flat
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.TruncateMilliseconds
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.TruncateSeconds
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.FirstOfMonth
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.EndOfMonth
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.FirstOfYear
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.EndOfYear
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.FirstOfWeek_Sunday
Wolfgang.Extensions.DateTime.Benchmarks.DateTimeExtensionsBenchmarks.EndOfWeek_Sunday
```

Baseline run will land via the follow-up benchmarks workflow PR (#159, P2).

## Stacked on

#186 (D2 CHANGELOG) — base of this PR.

## Closes

#158

🤖 Generated with [Claude Code](https://claude.com/claude-code)