### PR TITLE
pr.yaml: fix Stage 2 coverage parser — greedy .* turned 100% into 0%

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -880,11 +880,21 @@ jobs:
           $matchedCount   = 0
 
           foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
-            # Accept extra columns between the module name and the final
-            # percent (ReportGenerator Summary.txt commonly has line +
-            # branch + method coverage on the same row). Take the LAST
-            # percent on the line — that's the overall figure.
-            if ($line -match '^\s*(\S+)\s+.*(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
+            # Only consider top-level assembly rows: non-space first char,
+            # whitespace, then the coverage percent at end-of-line.
+            # Matches Stage 1's `^[^ ].*[0-9]+(\.[0-9]+)?%$` filter (which
+            # uses awk $NF for the percent — robust to extra columns).
+            #
+            # Bug previously here: a `.*` between the module name and the
+            # trailing `(\d+)%` was greedy and could eat all but the last
+            # digit of the percent — turning "100" into "0" and failing
+            # the gate on actually-100%-covered modules. Two changes:
+            #  - Anchor on `^(\S+)` so indented sub-class rows are skipped
+            #    (their parent assembly row carries the same number, so
+            #    nothing is lost — and Stage 1 ignores them too).
+            #  - Drop the `.*` and let `\s+` separate the module from the
+            #    final `\d+%` directly.
+            if ($line -match '^(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
               $percent = [int][math]::Floor([double]$Matches[2])
               $matchedCount++


### PR DESCRIPTION
## Why this is a protected-only PR

Isolates the `pr.yaml` regex fix on its own so it can be admin-bypass-merged to `main` once. After this lands, merging `main` back into `vNext` removes the protected-file delta from PR #183 and lets vNext merge as a pure unprotected-files PR with no further bypass.

## The bug

Stage 2 (Windows) coverage gate regex was:

```
^\s*(\S+)\s+.*(\d+(?:\.\d+)?)%\s*$
```

The greedy `.*` between the module name and the trailing `\d+%` ate all but the **last digit** of the percent. On lines like:

```
Wolfgang.Extensions.DateTime                         100%
```

…it captured `percent=0` (the trailing "0" of "100"), reported the module as failing the 90% threshold, and tanked the gate even on 100%-covered code. Reproduced locally against the actual Summary.txt from the failing run.

## The fix

Align with Stage 1 (Linux)'s awk-based parser:

- Anchor on `^(\S+)` to skip indented sub-class rows (Stage 1's `^[^ ]` does the same).
- Drop the `.*` — let `\s+` separate the module from the final `\d+%` directly. No greedy region to swallow digits.

After fix, parsing the same Summary.txt:

```
module: Wolfgang.Extensions.DateTime, percent: 100  → ✅ PASS
```

## Test plan

- [x] Reproduced the bug locally against the failing run's Summary.txt
- [x] Verified fixed regex extracts `percent=100` for the same input
- [ ] CI Stage 2 Windows passes on a follow-up vNext run after `main` merges back into vNext

## Note

This PR touches `.github/workflows/pr.yaml` — a protected file. The `Detect .NET Projects` guard will fire (that's its job). Admin-bypass to merge.

## Fleet implication

This same regex bug exists on all 25 other repos that picked up canonical-protected's pr.yaml. Fan-out to follow once this lands and the DateTime pilot completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)