### PR TITLE
pr.yaml: allow multi-column rows in Stage 2 coverage parser (Copilot follow-up to #189)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -881,9 +881,11 @@ jobs:
 
           foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
             # Only consider top-level assembly rows: non-space first char,
-            # whitespace, then the coverage percent at end-of-line.
+            # then anything, then whitespace + the final percent at EOL.
             # Matches Stage 1's `^[^ ].*[0-9]+(\.[0-9]+)?%$` filter (which
-            # uses awk $NF for the percent — robust to extra columns).
+            # uses awk $NF for the percent — robust to extra columns like
+            # line/branch/method that ReportGenerator can emit on the same
+            # row).
             #
             # Bug previously here: a `.*` between the module name and the
             # trailing `(\d+)%` was greedy and could eat all but the last
@@ -892,9 +894,14 @@ jobs:
             #  - Anchor on `^(\S+)` so indented sub-class rows are skipped
             #    (their parent assembly row carries the same number, so
             #    nothing is lost — and Stage 1 ignores them too).
-            #  - Drop the `.*` and let `\s+` separate the module from the
-            #    final `\d+%` directly.
-            if ($line -match '^(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
+            #  - Require whitespace immediately before the final `\d+%`
+            #    (`\s(\d+...)%\s*$`). This still allows intermediate
+            #    columns between the module name and the final percent
+            #    (the `.*` consumes them), but `.*` can't terminate
+            #    mid-digit-run — the regex engine MUST place `\s` before
+            #    the digits, which forces the last %-suffixed number on
+            #    the line to be captured intact.
+            if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
               $percent = [int][math]::Floor([double]$Matches[2])
               $matchedCount++


### PR DESCRIPTION
## Why

Follow-up to #189 (already merged). Copilot's review on that PR flagged a real edge case I missed — the first-iteration regex required the percent to be adjacent to the module's trailing whitespace, which would zero-match if ReportGenerator emits intermediate line/branch/method columns on the assembly row (a layout Stage 1's comment explicitly accommodates).

## The change

```diff
- if ($line -match '^(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
+ if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
```

The `.*` between the module name and `\s(\d+)%$` allows intermediate columns. The `\s` immediately before the digit group forces the regex engine to place whitespace before the digits — so `.*` cannot terminate mid-digit-run. Captures the last `%`-suffixed number on the line (matching Stage 1's awk `$NF` semantics) without the original digit-eating behaviour.

## Verified against

| Input | Captured | Expected |
|---|---|---|
| `Wolfgang…DateTime    100%` | `100` | ✅ single column |
| `Wolfgang…DateTime 100% 95% 87%` | `87` | ✅ last %, multi-column |
| `  Line coverage: 100%` | (skip) | ✅ leading space |
| `  Wolfgang…Extensions    100%` | (skip) | ✅ indented sub-row |
| `Method coverage: 100% (10 of 10)` | (skip) | ✅ trailing text |

## Note

Protected file change — `Detect .NET Projects` guard will fire, admin-bypass at merge (same pattern as #189).

## Fleet implication

Fan-out to 24 other canonical-protected branches still pending. After this lands, the fan-out commit will carry this regex (multi-column safe) instead of the #189 one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)