### PR TITLE
A1: activate PublicApiAnalyzer baseline (post-1.0 stability contract)

### DIFF
--- a/src/Wolfgang.Extensions.DateTime/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.DateTime/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfMonth(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfWeek(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfWeek(this System.DateTime dateTime, System.DayOfWeek firstDayOfWeek) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfYear(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfMonth(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfWeek(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfWeek(this System.DateTime dateTime, System.DayOfWeek firstDayOfWeek) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.TruncateMilliseconds(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.TruncateSeconds(this System.DateTime dateTime) -> System.DateTime
+Wolfgang.Extensions.DateTime.DateTimeExtensions

--- a/src/Wolfgang.Extensions.DateTime/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.DateTime/PublicAPI.Shipped.txt
@@ -6,6 +6,7 @@ static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfYear(this System.Dat
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfMonth(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfWeek(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfWeek(this System.DateTime dateTime, System.DayOfWeek firstDayOfWeek) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfYear(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.TruncateMilliseconds(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.TruncateSeconds(this System.DateTime dateTime) -> System.DateTime
 Wolfgang.Extensions.DateTime.DateTimeExtensions

--- a/src/Wolfgang.Extensions.DateTime/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.DateTime/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

Activates the `PublicApiAnalyzer` scaffolding that's been silent in this repo since the A1 canonical work. Adds two text files alongside the src csproj:

- **`PublicAPI.Shipped.txt`** — baseline of the current public surface (10 extension method overloads + the static class), sorted alphabetically per analyzer convention.
- **`PublicAPI.Unshipped.txt`** — header-only, ready to accumulate diffs against the Shipped baseline.

## What this gates from now on

Any change to the public surface of `Wolfgang.Extensions.DateTime` will surface as `RS0016` (or `*REMOVED*` on Shipped) at compile time. New additions land in `Unshipped.txt` first via the analyzer's IDE code-fix, then promote to `Shipped.txt` at release time as part of the version-bump commit.

**Posture for this repo: post-1.0 stability contract.** The package is currently at 1.2.0; the Shipped baseline locks in the public surface that 1.x consumers depend on. Removing or changing the signature of an existing entry from this point forward should be treated as a breaking change requiring a major-version bump.

## Verification

Clean-rebuilt with PublicApiAnalyzer 3.3.4 (loaded via `Directory.Build.props` since A1 canonical):

```
0 RS0016 warnings  (no missing API entries — every public symbol covered)
0 RS0017 warnings  (no Shipped/Unshipped entries without matching symbol)
0 Errors
```

10 method overloads + the static class are all listed:

- `TruncateMilliseconds`, `TruncateSeconds`
- `FirstOfMonth`, `EndOfMonth`
- `FirstOfYear`, `EndOfYear`
- `FirstOfWeek()`, `FirstOfWeek(DayOfWeek)`
- `EndOfWeek()`, `EndOfWeek(DayOfWeek)`
- `Wolfgang.Extensions.DateTime.DateTimeExtensions` (the class itself)

## Closes

#174

🤖 Generated with [Claude Code](https://claude.com/claude-code)