### PR TITLE
C5: AI code-review pass — fix EndOfWeek doc + trailing whitespace

### DIFF
--- a/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
+++ b/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
@@ -130,7 +130,7 @@ public static class DateTimeExtensions
     /// <summary>
     /// Returns a new DateTime that represents the first day of the
     /// week specified by the DateTime passed in using the thread's
-    /// CurrentCulture FirstDayOfWeek 
+    /// CurrentCulture FirstDayOfWeek.
     /// </summary>
     /// <param name="dateTime">The value to process.</param>
     /// <returns>A new DateTime representing the first of the week.</returns>
@@ -178,7 +178,7 @@ public static class DateTimeExtensions
     /// <summary>
     /// Returns a new DateTime that represents the last day of the
     /// week specified by the DateTime passed in using the thread's
-    /// CurrentCulture FirstDayOfWeek 
+    /// CurrentCulture FirstDayOfWeek.
     /// </summary>
     /// <param name="dateTime">The value to process.</param>
     /// <returns>A new DateTime representing the end of the week.</returns>
@@ -190,10 +190,10 @@ public static class DateTimeExtensions
     /// <summary>
     /// Returns a new DateTime that represents the last day of the
     /// week specified by the DateTime passed in using the specified
-    /// firstDayOfWeek
+    /// firstDayOfWeek.
     /// </summary>
     /// <param name="dateTime">The value to process.</param>
-    /// <param name="firstDayOfWeek">Specifies the first day of the week. Default is Sunday.</param>
+    /// <param name="firstDayOfWeek">Specifies the first day of the week. Use the parameterless overload to pick up <see cref="CultureInfo.CurrentCulture"/>'s value automatically.</param>
     /// <returns>A new DateTime representing the end of the week.</returns>
     public static System.DateTime EndOfWeek(this System.DateTime dateTime, DayOfWeek firstDayOfWeek)
     {
@@ -205,4 +205,4 @@ public static class DateTimeExtensions
             ? new System.DateTime(maxTicks, dateTime.Kind)
             : firstOfWeek.AddDays(7).AddTicks(-1);
     }
-} 
+}


### PR DESCRIPTION
## Summary

Tier-1 #156 — AI code-review pass on `src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs` (208 lines, 10 method overloads).

## Findings fixed in this PR

| # | Finding | Why it matters |
|---|---|---|
| 1 | `EndOfWeek(DayOfWeek)` XML-doc said *"Default is Sunday"* for `firstDayOfWeek` | The overload has no default. Sunday is only `en-US`'s `CurrentCulture.FirstDayOfWeek`, not a property of this method. Misleading for non-en-US readers. |
| 2 | Trailing whitespace on two summary lines | Cosmetic; `dotnet format` would strip on next run |
| 3 | Trailing space on the class-closing `}` line 208 | Same |

The XML-doc rewrite for finding #1 also adds a `<see cref="CultureInfo"/>` crossreference so IDE tooltips link to the right type, and points readers at the parameterless overload for culture-aware behaviour.

## Findings deliberately deferred to Tier-2

- **Repeated 8-arg `new DateTime(...)` constructor pattern** in 4 methods (TruncateMilliseconds, TruncateSeconds, FirstOfMonth, FirstOfYear). A private `MidnightOf(year, month, day, kind)` helper would DRY it, but the explicit pattern is arguably clearer for a behaviour-defining library — and changing it later carries zero risk since the IL is identical. Not worth churning now.
- **`[Pure]` attribute on each method** — these are all pure functions but not marked `[System.Diagnostics.Contracts.Pure]`. Adding it would let consumers' static analysis flag side-effect-free calls, but it's a separate consideration that should be applied fleet-wide.

## What was NOT found

No correctness, performance, security, or API-surface issues. Specifically verified:

- Boundary handling clamps at `DateTime.MinValue`/`MaxValue` for all four `End*`/`First*` boundary methods (no overflow exceptions).
- `DateTimeKind` is preserved through every transformation (input's `Kind` flows to the returned value via the 8-arg constructor's `kind` parameter, and `Date` / `AddDays` / `AddTicks` preserve `Kind` per BCL semantics).
- The 8-parameter `DateTime` ctor with explicit `millisecond=0` is used everywhere — removes the culture-dependent ambiguity that bit `TruncateMilliseconds`/`TruncateSeconds` in v1.0.0 (fixed in v1.1.0; current code is correct).
- `CurrentCulture.DateTimeFormat.FirstDayOfWeek` lookup happens on every call to the parameterless `FirstOfWeek()`/`EndOfWeek()` — that's a known cost the new `*_CurrentCulture` benchmarks added in #187 specifically measure. Not a bug, by design.

## Closes

#156

🤖 Generated with [Claude Code](https://claude.com/claude-code)