### PR TITLE
N1: add FirstOfQuarter / EndOfQuarter / FirstOfHalf / EndOfHalf (v1.3.0 candidate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FirstOfQuarter()` / `EndOfQuarter()` extension methods returning the
+  first day (at 00:00) and last tick of the calendar quarter containing
+  the input. Quarters: Q1 Jan-Mar, Q2 Apr-Jun, Q3 Jul-Sep, Q4 Oct-Dec.
+  `EndOfQuarter()` clamps at `DateTime.MaxValue` for Q4 of year 9999.
+- `FirstOfHalf()` / `EndOfHalf()` extension methods returning the
+  first day (at 00:00) and last tick of the calendar half-year
+  containing the input. Halves: H1 Jan-Jun, H2 Jul-Dec. `EndOfHalf()`
+  clamps at `DateTime.MaxValue` for H2 of year 9999.
+- All four new methods preserve the input's `DateTimeKind` and are
+  covered by unit tests across every TFM (Theory cases for all 12
+  input months on Quarter, all 12 on Half, plus boundary + Kind tests)
+  and by gh-pages benchmark chart series.
+
 ### Changed
 
 - Analyzer `PackageReference`s consolidated back into `Directory.Build.props`

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ authoritative list (kept in sync with source on every release), see the
 | `FirstOfWeek(DayOfWeek firstDayOfWeek)`| Uses the specified first day of the week to locate the week’s starting `DateTime`. |
 | `EndOfWeek()`| Uses the current culture’s first day, calculates the final tick of the week. |
 | `EndOfWeek(DayOfWeek firstDayOfWeek)`| Uses the specified first day, calculates the final tick of the week. |
+| `FirstOfQuarter`| Returns the first day of the calendar quarter (Q1 Jan-Mar, Q2 Apr-Jun, Q3 Jul-Sep, Q4 Oct-Dec) at 00:00. |
+| `EndOfQuarter`| Returns the final tick of the calendar quarter. Clamps at `DateTime.MaxValue` for Q4 of year 9999. |
+| `FirstOfHalf`| Returns the first day of the calendar half-year (H1 Jan-Jun, H2 Jul-Dec) at 00:00. |
+| `EndOfHalf`| Returns the final tick of the calendar half-year. Clamps at `DateTime.MaxValue` for H2 of year 9999. |
 
 
 

--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
@@ -74,4 +74,24 @@ public class DateTimeExtensionsBenchmarks
 
     [Benchmark]
     public System.DateTime EndOfWeek_CurrentCulture() => Sample.EndOfWeek();
+
+
+
+    [Benchmark]
+    public System.DateTime FirstOfQuarter() => Sample.FirstOfQuarter();
+
+
+
+    [Benchmark]
+    public System.DateTime EndOfQuarter() => Sample.EndOfQuarter();
+
+
+
+    [Benchmark]
+    public System.DateTime FirstOfHalf() => Sample.FirstOfHalf();
+
+
+
+    [Benchmark]
+    public System.DateTime EndOfHalf() => Sample.EndOfHalf();
 }

--- a/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
+++ b/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
@@ -205,4 +205,92 @@ public static class DateTimeExtensions
             ? new System.DateTime(maxTicks, dateTime.Kind)
             : firstOfWeek.AddDays(7).AddTicks(-1);
     }
+
+
+
+    /// <summary>
+    /// Returns a new DateTime that represents the first day of the
+    /// calendar quarter containing the specified DateTime. Quarters are:
+    /// Q1 Jan-Mar, Q2 Apr-Jun, Q3 Jul-Sep, Q4 Oct-Dec.
+    /// </summary>
+    /// <param name="dateTime">The value to process.</param>
+    /// <returns>A new DateTime representing the first of the quarter at 00:00:00.</returns>
+    public static System.DateTime FirstOfQuarter(this System.DateTime dateTime)
+    {
+        var quarterStartMonth = (((dateTime.Month - 1) / 3) * 3) + 1;
+        return new System.DateTime
+        (
+            dateTime.Year,
+            quarterStartMonth,
+            1,
+            0,
+            0,
+            0,
+            0,
+            dateTime.Kind
+        );
+    }
+
+
+
+    /// <summary>
+    /// Returns a new DateTime that represents the last tick of the
+    /// calendar quarter containing the specified DateTime. Clamps at
+    /// <see cref="System.DateTime.MaxValue"/> when the quarter is Q4 of
+    /// year 9999.
+    /// </summary>
+    /// <param name="dateTime">The value to process.</param>
+    /// <returns>A new DateTime representing the end of the quarter.</returns>
+    public static System.DateTime EndOfQuarter(this System.DateTime dateTime)
+    {
+        var firstOfQuarter = dateTime.FirstOfQuarter();
+
+        return firstOfQuarter.Month == 10 && firstOfQuarter.Year == 9999
+            ? new System.DateTime(System.DateTime.MaxValue.Ticks, dateTime.Kind)
+            : firstOfQuarter.AddMonths(3).AddTicks(-1);
+    }
+
+
+
+    /// <summary>
+    /// Returns a new DateTime that represents the first day of the
+    /// calendar half-year containing the specified DateTime. Halves are:
+    /// H1 Jan-Jun, H2 Jul-Dec.
+    /// </summary>
+    /// <param name="dateTime">The value to process.</param>
+    /// <returns>A new DateTime representing the first of the half-year at 00:00:00.</returns>
+    public static System.DateTime FirstOfHalf(this System.DateTime dateTime)
+    {
+        var halfStartMonth = dateTime.Month <= 6 ? 1 : 7;
+        return new System.DateTime
+        (
+            dateTime.Year,
+            halfStartMonth,
+            1,
+            0,
+            0,
+            0,
+            0,
+            dateTime.Kind
+        );
+    }
+
+
+
+    /// <summary>
+    /// Returns a new DateTime that represents the last tick of the
+    /// calendar half-year containing the specified DateTime. Clamps at
+    /// <see cref="System.DateTime.MaxValue"/> when the half is H2 of
+    /// year 9999.
+    /// </summary>
+    /// <param name="dateTime">The value to process.</param>
+    /// <returns>A new DateTime representing the end of the half-year.</returns>
+    public static System.DateTime EndOfHalf(this System.DateTime dateTime)
+    {
+        var firstOfHalf = dateTime.FirstOfHalf();
+
+        return firstOfHalf.Month == 7 && firstOfHalf.Year == 9999
+            ? new System.DateTime(System.DateTime.MaxValue.Ticks, dateTime.Kind)
+            : firstOfHalf.AddMonths(6).AddTicks(-1);
+    }
 }

--- a/src/Wolfgang.Extensions.DateTime/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.DateTime/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfHalf(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfQuarter(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfHalf(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfQuarter(this System.DateTime dateTime) -> System.DateTime

--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14</LangVersion>
-		<Version>1.2.0</Version>
+		<Version>1.3.0</Version>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>

--- a/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
@@ -451,7 +451,7 @@ public class DateTimeExtensionsTests
         Assert.Equal(23, result.Hour);
         Assert.Equal(59, result.Minute);
         Assert.Equal(59, result.Second);
-        Assert.Equal(9999999L, result.Ticks % TimeSpan.TicksPerSecond);
+        Assert.Equal(TimeSpan.TicksPerSecond - 1, result.Ticks % TimeSpan.TicksPerSecond);
         Assert.Equal(DateTimeKind.Utc, result.Kind);
     }
 
@@ -530,7 +530,7 @@ public class DateTimeExtensionsTests
         Assert.Equal(23, result.Hour);
         Assert.Equal(59, result.Minute);
         Assert.Equal(59, result.Second);
-        Assert.Equal(9999999L, result.Ticks % TimeSpan.TicksPerSecond);
+        Assert.Equal(TimeSpan.TicksPerSecond - 1, result.Ticks % TimeSpan.TicksPerSecond);
         Assert.Equal(DateTimeKind.Utc, result.Kind);
     }
 

--- a/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
@@ -398,4 +398,164 @@ public class DateTimeExtensionsTests
 
         Assert.Equal(System.DateTimeKind.Local, result.Kind);
     }
+
+
+
+    // ----- FirstOfQuarter / EndOfQuarter -----
+
+    [Theory]
+    [InlineData(1,  1)]   // Jan → Q1 starts Jan 1
+    [InlineData(2,  1)]   // Feb → Q1
+    [InlineData(3,  1)]   // Mar → Q1
+    [InlineData(4,  4)]   // Apr → Q2 starts Apr 1
+    [InlineData(5,  4)]
+    [InlineData(6,  4)]
+    [InlineData(7,  7)]   // Jul → Q3
+    [InlineData(8,  7)]
+    [InlineData(9,  7)]
+    [InlineData(10, 10)]  // Oct → Q4
+    [InlineData(11, 10)]
+    [InlineData(12, 10)]
+    public void FirstOfQuarter_returns_the_first_day_of_the_quarter(int inputMonth, int expectedQuarterStartMonth)
+    {
+        var input = new DateTime(2026, inputMonth, 15, 14, 30, 45, 123, DateTimeKind.Utc);
+
+        var result = input.FirstOfQuarter();
+
+        Assert.Equal(2026, result.Year);
+        Assert.Equal(expectedQuarterStartMonth, result.Month);
+        Assert.Equal(1, result.Day);
+        Assert.Equal(0, result.Hour);
+        Assert.Equal(0, result.Minute);
+        Assert.Equal(0, result.Second);
+        Assert.Equal(0, result.Millisecond);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+
+
+    [Theory]
+    [InlineData(1,  3,  31)]   // Q1 ends Mar 31
+    [InlineData(4,  6,  30)]   // Q2 ends Jun 30
+    [InlineData(7,  9,  30)]   // Q3 ends Sep 30
+    [InlineData(10, 12, 31)]   // Q4 ends Dec 31
+    public void EndOfQuarter_returns_the_last_tick_of_the_quarter(int inputMonth, int expectedEndMonth, int expectedEndDay)
+    {
+        var input = new DateTime(2026, inputMonth, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = input.EndOfQuarter();
+
+        Assert.Equal(2026, result.Year);
+        Assert.Equal(expectedEndMonth, result.Month);
+        Assert.Equal(expectedEndDay, result.Day);
+        Assert.Equal(23, result.Hour);
+        Assert.Equal(59, result.Minute);
+        Assert.Equal(59, result.Second);
+        Assert.Equal(9999999L, result.Ticks % TimeSpan.TicksPerSecond);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+
+
+    [Fact]
+    public void EndOfQuarter_when_DateTime_MaxValue_clamps_to_MaxValue()
+    {
+        var input = new DateTime(9999, 11, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var result = input.EndOfQuarter();
+
+        Assert.Equal(DateTime.MaxValue.Ticks, result.Ticks);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+
+
+    [Fact]
+    public void FirstOfQuarter_preserves_Kind()
+    {
+        var input = new DateTime(2026, 5, 15, 0, 0, 0, DateTimeKind.Local);
+
+        var result = input.FirstOfQuarter();
+
+        Assert.Equal(DateTimeKind.Local, result.Kind);
+    }
+
+
+
+    // ----- FirstOfHalf / EndOfHalf -----
+
+    [Theory]
+    [InlineData(1,  1)]   // Jan → H1
+    [InlineData(2,  1)]
+    [InlineData(3,  1)]
+    [InlineData(4,  1)]
+    [InlineData(5,  1)]
+    [InlineData(6,  1)]
+    [InlineData(7,  7)]   // Jul → H2
+    [InlineData(8,  7)]
+    [InlineData(9,  7)]
+    [InlineData(10, 7)]
+    [InlineData(11, 7)]
+    [InlineData(12, 7)]
+    public void FirstOfHalf_returns_the_first_day_of_the_half_year(int inputMonth, int expectedHalfStartMonth)
+    {
+        var input = new DateTime(2026, inputMonth, 15, 14, 30, 45, 123, DateTimeKind.Utc);
+
+        var result = input.FirstOfHalf();
+
+        Assert.Equal(2026, result.Year);
+        Assert.Equal(expectedHalfStartMonth, result.Month);
+        Assert.Equal(1, result.Day);
+        Assert.Equal(0, result.Hour);
+        Assert.Equal(0, result.Minute);
+        Assert.Equal(0, result.Second);
+        Assert.Equal(0, result.Millisecond);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+
+
+    [Theory]
+    [InlineData(1, 6,  30)]   // H1 ends Jun 30
+    [InlineData(7, 12, 31)]   // H2 ends Dec 31
+    public void EndOfHalf_returns_the_last_tick_of_the_half_year(int inputMonth, int expectedEndMonth, int expectedEndDay)
+    {
+        var input = new DateTime(2026, inputMonth, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = input.EndOfHalf();
+
+        Assert.Equal(2026, result.Year);
+        Assert.Equal(expectedEndMonth, result.Month);
+        Assert.Equal(expectedEndDay, result.Day);
+        Assert.Equal(23, result.Hour);
+        Assert.Equal(59, result.Minute);
+        Assert.Equal(59, result.Second);
+        Assert.Equal(9999999L, result.Ticks % TimeSpan.TicksPerSecond);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+
+
+    [Fact]
+    public void EndOfHalf_when_DateTime_MaxValue_clamps_to_MaxValue()
+    {
+        var input = new DateTime(9999, 9, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var result = input.EndOfHalf();
+
+        Assert.Equal(DateTime.MaxValue.Ticks, result.Ticks);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+
+
+    [Fact]
+    public void FirstOfHalf_preserves_Kind()
+    {
+        var input = new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Local);
+
+        var result = input.FirstOfHalf();
+
+        Assert.Equal(DateTimeKind.Local, result.Kind);
+    }
 }


### PR DESCRIPTION
## Summary

Four new public extension methods following the existing `FirstOf*` / `EndOf*` naming convention (per #22, with `FirstOf` preferred over `BeginningOf`):

| Method | Returns | Boundary clamp |
|---|---|---|
| `FirstOfQuarter(this DateTime)` | First day of calendar quarter (Q1 Jan-Mar, Q2 Apr-Jun, Q3 Jul-Sep, Q4 Oct-Dec) at 00:00 | — |
| `EndOfQuarter(this DateTime)` | Final tick of calendar quarter | `DateTime.MaxValue` for Q4 of year 9999 |
| `FirstOfHalf(this DateTime)` | First day of calendar half-year (H1 Jan-Jun, H2 Jul-Dec) at 00:00 | — |
| `EndOfHalf(this DateTime)` | Final tick of calendar half-year | `DateTime.MaxValue` for H2 of year 9999 |

All four preserve the input's `DateTimeKind` via the 8-parameter `DateTime` constructor. Boundary clamping mirrors the existing pattern in `EndOfMonth` (Dec/9999) and `EndOfYear` (9999).

## Verification

- **Build (Release, all TFMs):** 0 warnings, 0 errors
- **Tests:** 66 → **100 per TFM** (+34) — 1200 cases per full matrix run
- **PublicAPI analyzer:** clean rebuild, 0 RS0016/RS0017 with 4 new entries in `PublicAPI.Unshipped.txt`
- **Benchmarks:** 4 new `[Benchmark]` methods picked up by `--list flat`

## Version impact

Bumps `src/.../Wolfgang.Extensions.DateTime.csproj` `<Version>` from **1.2.0 → 1.3.0** (MINOR per SemVer — additive only, no existing surface changed).

The release flow that was queued for `v1.2.1` becomes `v1.3.0`. If you'd rather ship the CI/maintenance work first as `v1.2.1` and these features as a separate `v1.3.0` follow-up, the version bump can be split into a separate commit — say the word and I'll restructure.

## Stacked on

#192 (A1 PublicApi baseline) — base of this PR. The PublicAPI files only exist after #192 lands, so the 4 new Unshipped entries need #192's `Shipped.txt`+`Unshipped.txt` scaffolding in place.

## Closes

#22

🤖 Generated with [Claude Code](https://claude.com/claude-code)