### PR TITLE
Add benchmarks.yaml — protected-only PR ahead of vNext merge

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,111 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize all writes to the gh-pages branch — both within this workflow
+# (two main pushes close together) and across workflows that also publish
+# to gh-pages (docfx.yaml, release.yaml). The shared `gh-pages` group name
+# means GitHub Actions queues any of those jobs behind the others when
+# they overlap, preventing non-fast-forward push failures and lost
+# updates. cancel-in-progress: false — every merge represents a meaningful
+# data point, so we queue rather than discard.
+#
+# NOTE: docfx.yaml and release.yaml currently have no `concurrency:` block,
+# so cross-workflow serialization is only partial today. Adding the same
+# `gh-pages` group to those workflows is tracked as a fleet-wide follow-up.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to push the rendered chart + history to the gh-pages branch.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Wolfgang.Extensions.DateTime.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Wolfgang.Extensions.DateTime.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.Extensions.DateTime.Benchmarks
+        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
+        # are noisy, so chart trends are reliable for allocations and double-digit
+        # time changes; smaller deltas are not.
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/Wolfgang.Extensions.DateTime.Benchmarks
+        run: |
+          # BDN's --exporters json writes one *-report-full-compressed.json per
+          # benchmark class. github-action-benchmark consumes a single file, so
+          # we combine the .Benchmarks arrays into one synthetic report.
+          # nullglob: empty match expands to nothing (instead of the literal
+          # pattern), so the explicit "no report found" branch can run before
+          # set -e + pipefail aborts the step.
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        # Pinned to v1.22.1 commit per repo convention (third-party actions
+        # publishing to gh-pages are pinned by SHA, not mutable tag).
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Don't fail the workflow if a metric regresses — this is a tracker,
+          # not a gate. Tighten later if the noise floor settles.
+          alert-threshold: '200%'
+          fail-on-alert: false


### PR DESCRIPTION
## Why protected-only

The same strategy as #189/#190: extract the single protected-file change from PR #183 (vNext → main) into its own admin-bypass merge against main. Once this lands, PR #183 no longer has any protected-file delta and can merge as a pure unprotected diff with no further bypass.

## The single change

Adds `.github/workflows/benchmarks.yaml` — the BenchmarkDotNet → gh-pages chart workflow. Identical content to what's currently on vNext (delivered originally by PR #188 + the concurrency-group tightening to address Copilot review).

## What it does

- **Trigger**: push to main when `src/`, `benchmarks/`, or `benchmarks.yaml` changes (+ `workflow_dispatch`)
- **Runtime**: BDN ShortRun (~3-5 min) against `Wolfgang.Extensions.DateTime.Benchmarks` (10 `[Benchmark]` methods covering every public extension method)
- **Output**: gh-pages `/dev/bench/` via `benchmark-action/github-action-benchmark@v1.22.1` (SHA-pinned per workflow-pin policy)
- **Concurrency**: shared `gh-pages` group name so it serializes against any other workflow writing to gh-pages (docfx.yaml, release.yaml — alignment of those is a tracked fleet-wide follow-up)
- **Chart URL after first run**: https://chris-wolfgang.github.io/DateTime-Extensions/dev/bench/

## Note

Protected file → `Detect .NET Projects` guard will fire. **Admin-bypass at merge.**

## Stage 1/2/3 status

The benchmark project itself isn't built by `pr.yaml` (Stage 1/2/3 don't enumerate `benchmarks/**`). This workflow is decoupled from PR validation by design — it runs on `push to main` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)