### PR TITLE
README: demo Q/H methods in Quick Start + Examples (post-1.3.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,13 +12,17 @@
 - `TruncateMilliseconds()` — zeroes out milliseconds
 - `TruncateSeconds()` — zeroes out seconds and milliseconds
 - `FirstOfMonth()` / `EndOfMonth()` — month boundary navigation
+- `FirstOfQuarter()` / `EndOfQuarter()` — calendar quarter boundary navigation (Q1 Jan-Mar, Q2 Apr-Jun, Q3 Jul-Sep, Q4 Oct-Dec)
+- `FirstOfHalf()` / `EndOfHalf()` — calendar half-year boundary navigation (H1 Jan-Jun, H2 Jul-Dec)
 - `FirstOfYear()` / `EndOfYear()` — year boundary navigation
 - `FirstOfWeek()` / `EndOfWeek()` — week boundary navigation (culture-aware + explicit DayOfWeek overloads)
 
 ## Important Notes
 - All methods preserve `DateTimeKind`
 - Use `System.DateTime` (fully qualified) to avoid namespace conflicts with the library namespace
-- `EndOfMonth/Year/Week` returns the last tick before the next period (`.AddTicks(-1)`)
+- `End*` methods return the last tick before the next period (`.AddTicks(-1)`) and clamp at `DateTime.MaxValue` when the next period would overflow
+- `FirstOfWeek` clamps at `DateTime.MinValue` when walking back to find the firstDayOfWeek would underflow
+- Public API is tracked by `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` — additions surface as RS0016 at compile time
 
 ## Code Style
 - Allman brace style

--- a/.gitignore
+++ b/.gitignore
@@ -437,3 +437,6 @@ docs/*
 
 # Claude Code local settings
 .claude/
+
+# DocFX-generated API YAML files (docfx metadata writes them; not tracked)
+docfx_project/api/*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   captures the v1.3.0 public surface (14 extension method overloads +
   the static class); future surface changes will surface as RS0016
   / *REMOVED* diffs at compile time.
-- BenchmarkDotNet baseline project (`benchmarks/Wolfgang.Extensions
-  .DateTime.Benchmarks`) plus `benchmarks.yaml` workflow that publishes
-  trend charts to gh-pages `/dev/bench/`.
+- BenchmarkDotNet baseline project
+  (`benchmarks/Wolfgang.Extensions.DateTime.Benchmarks`) plus
+  `benchmarks.yaml` workflow that publishes trend charts to gh-pages
+  `/dev/bench/`.
 - `<RepositoryUrl>` and `<PackageTags>` package metadata in src csproj.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.3.0] - 2026-05-26
+
+### Added
+
 - `FirstOfQuarter()` / `EndOfQuarter()` extension methods returning the
   first day (at 00:00) and last tick of the calendar quarter containing
   the input. Quarters: Q1 Jan-Mar, Q2 Apr-Jun, Q3 Jul-Sep, Q4 Oct-Dec.
@@ -21,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   covered by unit tests across every TFM (Theory cases for all 12
   input months on Quarter, all 12 on Half, plus boundary + Kind tests)
   and by gh-pages benchmark chart series.
+- `PublicApiAnalyzer` baseline activated. `PublicAPI.Shipped.txt`
+  captures the v1.3.0 public surface (14 extension method overloads +
+  the static class); future surface changes will surface as RS0016
+  / *REMOVED* diffs at compile time.
+- BenchmarkDotNet baseline project (`benchmarks/Wolfgang.Extensions
+  .DateTime.Benchmarks`) plus `benchmarks.yaml` workflow that publishes
+  trend charts to gh-pages `/dev/bench/`.
+- `<RepositoryUrl>` and `<PackageTags>` package metadata in src csproj.
 
 ### Changed
 
@@ -29,10 +51,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consolidated location is the single source of truth for the canonical
   template-sync flow; per-project opt-out is still available via overrides
   in a project's own csproj.
-
-### Deprecated
+- README rewritten: filled Quick Start + Examples, added NuGet / build /
+  release badges, moved DocFX troubleshooting out of README into
+  `docs/DOCFX-VERSION-PICKER.md`, corrected analyzer count (7 → 8 with
+  PublicApiAnalyzer), bumped build prereq from .NET 8.0 → 10.0 SDK.
+- `<AssemblyVersion>` dropped from src csproj — let SDK derive from
+  `<Version>` so all version metadata stays in lock-step on every bump
+  (the previously-hardcoded `1.0.0` was stale relative to released
+  package versions from v1.1.0 onward).
+- CHANGELOG seeded with v1.0.0 / v1.1.0 / v1.2.0 entries from git tag
+  history.
 
 ### Removed
+
+- `REPO-INSTRUCTIONS.md` template scaffolding (its own opening said
+  "delete this file after setup"; the repo has been live since v1.0.0).
+- `TEMPLATE-PLACEHOLDERS.md` and `TEMPLATE-REPO-PLACEHOLDERS-EXPLANATION.md`
+  template scaffolding files (also from initial setup, no longer needed).
 
 ### Fixed
 
@@ -86,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-framework targeting: `net462`, `netstandard2.0`,
   `netcoreapp3.1`, `net8.0`, `net10.0`.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/releases/tag/v1.0.0

--- a/DateTime-Extensions.slnx
+++ b/DateTime-Extensions.slnx
@@ -1,15 +1,16 @@
 <Solution>
   <Folder Name="/.root/">
     <File Path=".editorconfig" />
+    <File Path=".gitattributes" />
     <File Path=".gitignore" />
     <File Path="BannedSymbols.txt" />
+    <File Path="CHANGELOG.md" />
     <File Path="CODE_OF_CONDUCT.md" />
     <File Path="CONTRIBUTING.md" />
     <File Path="Directory.Build.props" />
-    <File Path="format.ps1" />
     <File Path="LICENSE" />
-    <File Path="LICENSE-SELECTION.md" />
     <File Path="README.md" />
+    <File Path="SECURITY.md" />
   </Folder>
   <Folder Name="/.root/docs/">
     <File Path="docs/DOCFX-VERSION-PICKER.md" />
@@ -25,23 +26,28 @@
   </Folder>
   <Folder Name="/.root/.github/ISSUE_TEMPLATE/">
     <File Path=".github/ISSUE_TEMPLATE/BUG_REPORT.yaml" />
-    <File Path=".github/ISSUE_TEMPLATE/feature_request.md" />
+    <File Path=".github/ISSUE_TEMPLATE/feature_request.yaml" />
+    <File Path=".github/ISSUE_TEMPLATE/maintenance-task.yaml" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
-    <File Path=".github/workflows/codeql.yml" />
-    <File Path=".github/workflows/create-labels.yaml" />
+    <File Path=".github/workflows/benchmarks.yaml" />
+    <File Path=".github/workflows/build-all-versions.yaml" />
+    <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
+    <File Path=".github/workflows/stryker.yaml" />
   </Folder>
   <Folder Name="/.root/assets/">
     <File Path="assets/icon.ico" />
     <File Path="assets/icon.png" />
   </Folder>
   <Folder Name="/.root/scripts/">
-    <File Path="scripts/Setup-BranchRuleset.ps1" />
-    <File Path="scripts/Setup-GitHubPages.ps1" />
-    <File Path="scripts/setup.ps1" />
+    <File Path="scripts/Fix-BranchRuleset.ps1" />
+    <File Path="scripts/Setup-Labels.ps1" />
+    <File Path="scripts/Validate-DocsDeploy.sh" />
+    <File Path="scripts/build-pr.ps1" />
+    <File Path="scripts/format.ps1" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/Wolfgang.Extensions.DateTime.Benchmarks.csproj" />
@@ -57,4 +63,3 @@
     <Project Path="tests/Wolfgang.Extensions.DateTime.Tests.Unit/Wolfgang.Extensions.DateTime.Tests.Unit.csproj" />
   </Folder>
 </Solution>
-

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ now.FirstOfWeek();                   // → first day of the week (current cultu
 now.FirstOfWeek(DayOfWeek.Monday);   // → first day of the week (explicit)
 now.EndOfWeek();                     // → last tick of the week (current culture)
 now.EndOfWeek(DayOfWeek.Monday);     // → last tick of the week (explicit)
+now.FirstOfQuarter();                // → first day of this calendar quarter
+now.EndOfQuarter();                  // → last tick of this calendar quarter
+now.FirstOfHalf();                   // → first day of this calendar half-year
+now.EndOfHalf();                     // → last tick of this calendar half-year
 ```
 
 All methods are pure: they return a new `DateTime` and never mutate the input. The
@@ -110,6 +114,11 @@ ts.EndOfYear();               // 2026-12-31 23:59:59.9999999 Utc
 
 ts.FirstOfWeek(DayOfWeek.Sunday); // 2026-05-24 00:00:00.000 Utc
 ts.EndOfWeek(DayOfWeek.Sunday);   // 2026-05-30 23:59:59.9999999 Utc
+
+ts.FirstOfQuarter();              // 2026-04-01 00:00:00.000 Utc  (Q2: Apr-Jun)
+ts.EndOfQuarter();                // 2026-06-30 23:59:59.9999999 Utc
+ts.FirstOfHalf();                 // 2026-01-01 00:00:00.000 Utc  (H1: Jan-Jun)
+ts.EndOfHalf();                   // 2026-06-30 23:59:59.9999999 Utc
 ```
 
 Boundary safety: `EndOfMonth`/`EndOfYear`/`EndOfWeek` clamp at

--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ ts.FirstOfHalf();                 // 2026-01-01 00:00:00.000 Utc  (H1: Jan-Jun)
 ts.EndOfHalf();                   // 2026-06-30 23:59:59.9999999 Utc
 ```
 
-Boundary safety: `EndOfMonth`/`EndOfYear`/`EndOfWeek` clamp at
-`DateTime.MaxValue` instead of throwing; `FirstOfWeek` clamps at
-`DateTime.MinValue`. See [CHANGELOG.md](CHANGELOG.md) v1.2.0 for the
-boundary fixes.
+Boundary safety: `EndOfMonth` / `EndOfYear` / `EndOfWeek` /
+`EndOfQuarter` / `EndOfHalf` all clamp at `DateTime.MaxValue` instead
+of throwing; `FirstOfWeek` clamps at `DateTime.MinValue`. See
+[CHANGELOG.md](CHANGELOG.md) v1.2.0 for the month / year / week
+boundary fixes and v1.3.0 for the quarter / half clamping added
+with the new methods.
 
 ---
 

--- a/examples/Wolfgang.Extensions.DateTime.DotNet462.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.DateTime.DotNet462.Example1/Program.cs
@@ -29,6 +29,14 @@ namespace Wolfgang.Extensions.DateTime.DotNet462.Example1
             Console.WriteLine($"\t  End of the current week: {System.DateTime.Today.EndOfWeek(DayOfWeek.Saturday)} (Saturday as first of week).");
             Console.WriteLine("\n");
 
+            Console.WriteLine($"\tFirst of the current quarter: {System.DateTime.Today.FirstOfQuarter()}.");
+            Console.WriteLine($"\t  End of the current quarter: {System.DateTime.Today.EndOfQuarter()}.");
+            Console.WriteLine("\n");
+
+            Console.WriteLine($"\tFirst of the current half-year: {System.DateTime.Today.FirstOfHalf()}.");
+            Console.WriteLine($"\t  End of the current half-year: {System.DateTime.Today.EndOfHalf()}.");
+            Console.WriteLine("\n");
+
             var now = System.DateTime.UtcNow;
             Console.WriteLine($"\t                 Now: {now:yyyy-MM-dd hh:mm:ss.fff tt}");
             Console.WriteLine($"\tTruncateMilliseconds: {now.TruncateMilliseconds():yyyy-MM-dd hh:mm:ss.fff tt}");

--- a/examples/Wolfgang.Extensions.DateTime.DotNet80.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.DateTime.DotNet80.Example1/Program.cs
@@ -31,6 +31,16 @@ internal static class Program
         Console.WriteLine($"\t  End of the current week: {System.DateTime.Today.EndOfWeek(DayOfWeek.Saturday)} (Saturday as first of week).");
 
 
+        Console.WriteLine("\n");
+        Console.WriteLine($"\tFirst of the current quarter: {System.DateTime.Today.FirstOfQuarter()}.");
+        Console.WriteLine($"\t  End of the current quarter: {System.DateTime.Today.EndOfQuarter()}.");
+
+
+        Console.WriteLine("\n");
+        Console.WriteLine($"\tFirst of the current half-year: {System.DateTime.Today.FirstOfHalf()}.");
+        Console.WriteLine($"\t  End of the current half-year: {System.DateTime.Today.EndOfHalf()}.");
+
+
         var now = System.DateTime.UtcNow;
         Console.WriteLine($"\t                 Now: {now:yyyy-MM-dd hh:mm:ss.fff tt}");
         Console.WriteLine($"\tTruncateMilliseconds: {now.TruncateMilliseconds():yyyy-MM-dd hh:mm:ss.fff tt}");

--- a/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
+++ b/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
@@ -13,10 +13,12 @@ public static class DateTimeExtensions
     /// <summary>
     /// Returns the midnight DateTime for a specific year/month/day with the
     /// given Kind. Centralises the 8-parameter <see cref="System.DateTime"/>
-    /// constructor pattern used by the four <c>FirstOf*</c> boundary methods
-    /// that return a midnight value (<see cref="FirstOfMonth"/>,
+    /// constructor pattern used by every <c>FirstOf*</c> boundary method
+    /// that returns a midnight value: <see cref="FirstOfMonth"/>,
     /// <see cref="FirstOfYear"/>, <see cref="FirstOfQuarter"/>,
-    /// <see cref="FirstOfHalf"/>).
+    /// <see cref="FirstOfHalf"/>, and the explicit-DayOfWeek overload of
+    /// <c>FirstOfWeek</c> (the parameterless overload just delegates to
+    /// that one via the current culture's <c>FirstDayOfWeek</c>).
     /// </summary>
     private static System.DateTime MidnightOf(int year, int month, int day, DateTimeKind kind)
         => new(year, month, day, 0, 0, 0, 0, kind);

--- a/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
+++ b/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
@@ -11,6 +11,19 @@ public static class DateTimeExtensions
 {
 
     /// <summary>
+    /// Returns the midnight DateTime for a specific year/month/day with the
+    /// given Kind. Centralises the 8-parameter <see cref="System.DateTime"/>
+    /// constructor pattern used by the four <c>FirstOf*</c> boundary methods
+    /// that return a midnight value (<see cref="FirstOfMonth"/>,
+    /// <see cref="FirstOfYear"/>, <see cref="FirstOfQuarter"/>,
+    /// <see cref="FirstOfHalf"/>).
+    /// </summary>
+    private static System.DateTime MidnightOf(int year, int month, int day, DateTimeKind kind)
+        => new(year, month, day, 0, 0, 0, 0, kind);
+
+
+
+    /// <summary>
     /// Remove the milliseconds and everything after the milliseconds
     /// </summary>
     /// <param name="dateTime">The value to process.</param>
@@ -57,17 +70,7 @@ public static class DateTimeExtensions
     /// <param name="dateTime">The value to process.</param>
     /// <returns>A new DateTime representing the first of the month.</returns>
     public static System.DateTime FirstOfMonth(this System.DateTime dateTime)
-        => new
-            (
-                dateTime.Year,
-                dateTime.Month,
-                1,
-                0,
-                0,
-                0,
-                0,
-                dateTime.Kind
-            );
+        => MidnightOf(dateTime.Year, dateTime.Month, 1, dateTime.Kind);
 
 
 
@@ -96,17 +99,7 @@ public static class DateTimeExtensions
     /// <param name="dateTime">The value to process.</param>
     /// <returns>A new DateTime representing the first of the year.</returns>
     public static System.DateTime FirstOfYear(this System.DateTime dateTime)
-        => new
-            (
-                dateTime.Year,
-                1,
-                1,
-                0,
-                0,
-                0,
-                0,
-                dateTime.Kind
-            );
+        => MidnightOf(dateTime.Year, 1, 1, dateTime.Kind);
 
 
 
@@ -160,17 +153,7 @@ public static class DateTimeExtensions
             firstOfWeek = firstOfWeek.AddDays(-1);
         }
 
-        return new System.DateTime
-        (
-            firstOfWeek.Year,
-            firstOfWeek.Month,
-            firstOfWeek.Day,
-            0,
-            0,
-            0,
-            0,
-            dateTime.Kind
-        );
+        return MidnightOf(firstOfWeek.Year, firstOfWeek.Month, firstOfWeek.Day, dateTime.Kind);
     }
 
 
@@ -218,17 +201,7 @@ public static class DateTimeExtensions
     public static System.DateTime FirstOfQuarter(this System.DateTime dateTime)
     {
         var quarterStartMonth = (((dateTime.Month - 1) / 3) * 3) + 1;
-        return new System.DateTime
-        (
-            dateTime.Year,
-            quarterStartMonth,
-            1,
-            0,
-            0,
-            0,
-            0,
-            dateTime.Kind
-        );
+        return MidnightOf(dateTime.Year, quarterStartMonth, 1, dateTime.Kind);
     }
 
 
@@ -262,17 +235,7 @@ public static class DateTimeExtensions
     public static System.DateTime FirstOfHalf(this System.DateTime dateTime)
     {
         var halfStartMonth = dateTime.Month <= 6 ? 1 : 7;
-        return new System.DateTime
-        (
-            dateTime.Year,
-            halfStartMonth,
-            1,
-            0,
-            0,
-            0,
-            0,
-            dateTime.Kind
-        );
+        return MidnightOf(dateTime.Year, halfStartMonth, 1, dateTime.Kind);
     }
 
 

--- a/src/Wolfgang.Extensions.DateTime/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.DateTime/PublicAPI.Shipped.txt
@@ -1,9 +1,13 @@
 #nullable enable
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfHalf(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfMonth(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfQuarter(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfWeek(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfWeek(this System.DateTime dateTime, System.DayOfWeek firstDayOfWeek) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfYear(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfHalf(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfMonth(this System.DateTime dateTime) -> System.DateTime
+static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfQuarter(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfWeek(this System.DateTime dateTime) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfWeek(this System.DateTime dateTime, System.DayOfWeek firstDayOfWeek) -> System.DateTime
 static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfYear(this System.DateTime dateTime) -> System.DateTime

--- a/src/Wolfgang.Extensions.DateTime/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.DateTime/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 #nullable enable
-static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfHalf(this System.DateTime dateTime) -> System.DateTime
-static Wolfgang.Extensions.DateTime.DateTimeExtensions.EndOfQuarter(this System.DateTime dateTime) -> System.DateTime
-static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfHalf(this System.DateTime dateTime) -> System.DateTime
-static Wolfgang.Extensions.DateTime.DateTimeExtensions.FirstOfQuarter(this System.DateTime dateTime) -> System.DateTime


### PR DESCRIPTION
## Summary

README Methods table at L72-86 listed all 14 public methods after v1.3.0, but the live code snippets (Quick Start L42, Examples L96) only demonstrated 10. New users learning the API from the README missed half the v1.3.0 additions.

This PR adds the 4 missing Q/H methods to both blocks with concrete example output (May 26 2026 → 2026 Q2 starts April).

## Stacked on
#201 (post-1.3.0 release-prep polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)