### PR TITLE
examples: demo Q/H methods in both example apps (post-1.3.0)

### DIFF
--- a/examples/Wolfgang.Extensions.DateTime.DotNet462.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.DateTime.DotNet462.Example1/Program.cs
@@ -29,6 +29,14 @@ namespace Wolfgang.Extensions.DateTime.DotNet462.Example1
             Console.WriteLine($"\t  End of the current week: {System.DateTime.Today.EndOfWeek(DayOfWeek.Saturday)} (Saturday as first of week).");
             Console.WriteLine("\n");
 
+            Console.WriteLine($"\tFirst of the current quarter: {System.DateTime.Today.FirstOfQuarter()}.");
+            Console.WriteLine($"\t  End of the current quarter: {System.DateTime.Today.EndOfQuarter()}.");
+            Console.WriteLine("\n");
+
+            Console.WriteLine($"\tFirst of the current half-year: {System.DateTime.Today.FirstOfHalf()}.");
+            Console.WriteLine($"\t  End of the current half-year: {System.DateTime.Today.EndOfHalf()}.");
+            Console.WriteLine("\n");
+
             var now = System.DateTime.UtcNow;
             Console.WriteLine($"\t                 Now: {now:yyyy-MM-dd hh:mm:ss.fff tt}");
             Console.WriteLine($"\tTruncateMilliseconds: {now.TruncateMilliseconds():yyyy-MM-dd hh:mm:ss.fff tt}");

--- a/examples/Wolfgang.Extensions.DateTime.DotNet80.Example1/Program.cs
+++ b/examples/Wolfgang.Extensions.DateTime.DotNet80.Example1/Program.cs
@@ -31,6 +31,16 @@ internal static class Program
         Console.WriteLine($"\t  End of the current week: {System.DateTime.Today.EndOfWeek(DayOfWeek.Saturday)} (Saturday as first of week).");
 
 
+        Console.WriteLine("\n");
+        Console.WriteLine($"\tFirst of the current quarter: {System.DateTime.Today.FirstOfQuarter()}.");
+        Console.WriteLine($"\t  End of the current quarter: {System.DateTime.Today.EndOfQuarter()}.");
+
+
+        Console.WriteLine("\n");
+        Console.WriteLine($"\tFirst of the current half-year: {System.DateTime.Today.FirstOfHalf()}.");
+        Console.WriteLine($"\t  End of the current half-year: {System.DateTime.Today.EndOfHalf()}.");
+
+
         var now = System.DateTime.UtcNow;
         Console.WriteLine($"\t                 Now: {now:yyyy-MM-dd hh:mm:ss.fff tt}");
         Console.WriteLine($"\tTruncateMilliseconds: {now.TruncateMilliseconds():yyyy-MM-dd hh:mm:ss.fff tt}");


### PR DESCRIPTION
## Summary

Both example projects (DotNet462 Example1 + DotNet80 Example1) demonstrated 10 of the 14 public methods after v1.3.0, missing the 4 Q/H methods. Adds 4 new `Console.WriteLine` blocks per example covering FirstOfQuarter / EndOfQuarter / FirstOfHalf / EndOfHalf.

Both example projects build clean against the v1.3.0 ProjectReference.

## Stacked on
#202 (README Q/H demo) → #201 (release-prep polish) → vNext

🤖 Generated with [Claude Code](https://claude.com/claude-code)