### PR TITLE
docs: sync version-picker.js header to canonical (repo-template#379 URL)

### DIFF
--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -10,7 +10,8 @@
 // detects the repo segment from window.location.pathname so the same
 // file works on github.io and on `docfx build --serve` localhost.
 //
-// Tracking issue: #170 (fleet-wide).
+// Canonical design + tracking lives at:
+//   https://github.com/Chris-Wolfgang/repo-template/issues/379
 (function () {
     'use strict';
 


### PR DESCRIPTION
## Summary

One-line tracking-comment update in `docfx_project/public/version-picker.js`:

```diff
-// Tracking issue: #170 (fleet-wide).
+// Canonical design + tracking lives at:
+//   https://github.com/Chris-Wolfgang/repo-template/issues/379
```

## Why

`repo-template`'s PR #393 (canonical version-picker landing in the template) got the same Copilot review point — `#170` is repo-local to DateTime-Extensions and meaningless once the file fans out elsewhere. The fix is a fully-qualified URL to `repo-template#379` (the canonical tracking issue).

Mirroring the change here so the two `version-picker.js` files stay byte-identical. Otherwise the next canonical template-sync into DateTime-Extensions would surface a 1-line drift on this comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)