### PR TITLE
Protected canonical sync: analyzer + workflow action bumps (admin-bypass)

### DIFF
--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -351,7 +351,7 @@ jobs:
         # Publishes the entire all_version_docs/ output directory to gh-pages
         # at the site root.  keep_files: true preserves any other content
         # already present on the branch (CNAME, root assets, etc.).
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ runner.temp }}/all_version_docs

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # security-extended adds the broader security query pack on top of the
@@ -159,7 +159,7 @@ jobs:
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,13 +53,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.93">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.94">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.26.0.140279">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -104,7 +104,7 @@
   <ItemGroup>
     <!-- SourceLink: embed source provenance into PDBs so debuggers can step
          into NuGet package code from GitHub. -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
## Summary

Extracted from PR #206 (vNext → main) to keep the protected-paths
diff in its own admin-bypass PR. After this merges, main → vNext will
absorb these, and PR #206 will be an entirely unprotected diff that
can merge without bypass.

## Protected files in this PR

- **`Directory.Build.props`**
  - `Meziantou.Analyzer` 3.0.93 → 3.0.94
  - `SonarAnalyzer.CSharp` 10.26.0 → 10.27.0
  - `Microsoft.SourceLink.GitHub` 8.0.0 → 10.0.300
- **`.github/workflows/codeql.yaml`**
  - `github/codeql-action/init` v3 → v4
  - `github/codeql-action/analyze` v3 → v4
- **`.github/workflows/build-all-versions.yaml`**
  - `peaceiris/actions-gh-pages` v4.0.0 → v4.1.0 (pinned SHA bump)

All come from the fleet-wide canonical sync; equivalent PRs have
landed on sibling repos.

## Merge sequence (per the protected-file-pr-split skill)

1. **Admin-bypass merge** this PR to `main`
2. Merge `main` → `vNext` locally and push (absorbs these changes onto vNext)
3. PR #206 then shows an unprotected-only diff; merge normally
4. Delete `protected/vNext-canonical-sync` and `vNext` branches