### PR TITLE
Release v1.3.1: restore AssemblyVersion + post-1.3.0 docs/CI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,34 @@ be cut for this set of changes.
 
 ### Deprecated
 
+## [1.3.1] - 2026-05-28
+
+### Fixed
+
+- **Binding stability on .NET Framework consumers.** v1.3.0 inadvertently
+  shipped with `AssemblyVersion=1.3.0.0` (SDK-derived from `<Version>`
+  after the explicit `<AssemblyVersion>1.0.0</AssemblyVersion>` line was
+  dropped in the v1.3.0 csproj cleanup). That changed the assembly's
+  binding identity vs the 1.0 / 1.1 / 1.2 line, which all shipped with
+  `AssemblyVersion=1.0.0.0`. Without a binding redirect, .NET Framework
+  consumers upgrading from any of those to v1.3.0 would have hit
+  `FileLoadException: Could not load file or assembly
+  'Wolfgang.Extensions.DateTime, Version=1.3.0.0, ...'`.
+
+  v1.3.1 restores the explicit pin: `<AssemblyVersion>1.0.0.0</AssemblyVersion>`.
+  Future minor/patch bumps on the 1.x line will keep this binding identity;
+  `AssemblyVersion` will only change on a deliberate breaking API change
+  (i.e., a 2.0 release). `<FileVersion>` now explicitly tracks
+  `$(Version).0` so file-version metadata still reflects every release.
+
+  Pre-1.3.0 → 1.3.1 consumers do not need a binding redirect (the binding
+  identity is the same `1.0.0.0` they already linked against). v1.3.0 →
+  1.3.1 consumers also do not need one going forward, but anyone on v1.3.0
+  today is referencing `Version=1.3.0.0` and will need either a binding
+  redirect or a re-reference + recompile to pick up 1.3.1. The damage from
+  v1.3.0 cannot be fully undone after release; v1.3.1 stops the bleeding
+  for everyone who hasn't yet adopted v1.3.0.
+
 ### Removed
 
 ### Fixed
@@ -142,7 +170,8 @@ be cut for this set of changes.
 - Multi-framework targeting: `net462`, `netstandard2.0`,
   `netcoreapp3.1`, `net8.0`, `net10.0`.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Chris-Wolfgang/DateTime-Extensions/compare/v1.0.0...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Docs, examples, CI, and an internal-only refactor. The public API and
-runtime behavior are unchanged from v1.3.0; no new NuGet release will
-be cut for this set of changes.
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.3.1] - 2026-05-28
 
 ### Added
 
@@ -27,21 +37,16 @@ be cut for this set of changes.
 - CI: canonical workflow sync (Stage 2 coverage regex, ruleset
   enforcement, version-picker.js header).
 
-### Deprecated
-
-## [1.3.1] - 2026-05-28
-
 ### Fixed
 
 - **Binding stability on .NET Framework consumers.** v1.3.0 inadvertently
   shipped with `AssemblyVersion=1.3.0.0` (SDK-derived from `<Version>`
-  after the explicit `<AssemblyVersion>1.0.0</AssemblyVersion>` line was
+  after the explicit `<AssemblyVersion>1.0.0.0</AssemblyVersion>` line was
   dropped in the v1.3.0 csproj cleanup). That changed the assembly's
   binding identity vs the 1.0 / 1.1 / 1.2 line, which all shipped with
   `AssemblyVersion=1.0.0.0`. Without a binding redirect, .NET Framework
   consumers upgrading from any of those to v1.3.0 would have hit
-  `FileLoadException: Could not load file or assembly
-  'Wolfgang.Extensions.DateTime, Version=1.3.0.0, ...'`.
+  `FileLoadException: Could not load file or assembly 'Wolfgang.Extensions.DateTime, Version=1.3.0.0, ...'`.
 
   v1.3.1 restores the explicit pin: `<AssemblyVersion>1.0.0.0</AssemblyVersion>`.
   Future minor/patch bumps on the 1.x line will keep this binding identity;
@@ -56,16 +61,9 @@ be cut for this set of changes.
   redirect or a re-reference + recompile to pick up 1.3.1. The damage from
   v1.3.0 cannot be fully undone after release; v1.3.1 stops the bleeding
   for everyone who hasn't yet adopted v1.3.0.
-
-### Removed
-
-### Fixed
-
 - `PublicAPI.Shipped.txt`: promoted the four Q/H entries that were left in
   `PublicAPI.Unshipped.txt` at the v1.3.0 tag. The methods themselves
   shipped in v1.3.0; this is a metadata correction, not an API change.
-
-### Security
 
 ## [1.3.0] - 2026-05-26
 

--- a/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
+++ b/src/Wolfgang.Extensions.DateTime/Wolfgang.Extensions.DateTime.csproj
@@ -3,21 +3,30 @@
 	<PropertyGroup>
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14</LangVersion>
-		<Version>1.3.0</Version>
+		<Version>1.3.1</Version>
+		<!-- Pin AssemblyVersion to MAJOR.0.0.0 so .NET Framework consumers
+		     don't need a binding redirect on every minor/patch bump. Only
+		     change this on a deliberate breaking API change (i.e., MAJOR
+		     bump per SemVer). FileVersion + InformationalVersion (the
+		     latter auto-derived from <Version>+SourceLink sha) carry the
+		     actual release version.
+
+		     Note: v1.0.0 / v1.1.0 / v1.2.0 shipped with AssemblyVersion=
+		     1.0.0.0 (the previously-hardcoded value, which was correct).
+		     v1.3.0 shipped with AssemblyVersion=1.3.0.0 (SDK-derived from
+		     <Version> after the original line was dropped) — a one-time
+		     binding break vs the 1.0-1.2 line that .NET Framework consumers
+		     would have needed a binding redirect to absorb. v1.3.1 restores
+		     the original AssemblyVersion=1.0.0.0 so future releases are
+		     once again binding-compatible across the 1.x line. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$(Version).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for DateTime</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DateTime-Extensions.git</RepositoryUrl>
 		<PackageTags>dotnet;extensions;datetime;date;time;truncate;firstofmonth;endofmonth;firstofweek;endofweek;firstofyear;endofyear</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<!-- AssemblyVersion / FileVersion / InformationalVersion default
-		     from <Version> when not explicitly set, so they track every
-		     <Version> bump automatically instead of going stale. They are
-		     not byte-identical: AssemblyVersion is normalized to a 4-part
-		     System.Version (1.2.0 → 1.2.0.0), and InformationalVersion
-		     can pick up a +<git-sha> suffix under SourceLink. The goal is
-		     "they all reflect the current Version", not "they all match
-		     character-for-character". -->
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary

Cuts v1.3.1. Bundles the AssemblyVersion restoration (PR #208) with the
post-1.3.0 docs, examples, CI, and metadata work already on vNext from
PR #206.

## Changes since v1.3.0

- `Wolfgang.Extensions.DateTime.csproj` — `<Version>` bumped to 1.3.1,
  `<AssemblyVersion>` restored (per PR #208 / fleet-wide AssemblyVersion
  audit)
- `CHANGELOG.md` — `[1.3.1] - 2026-05-28` section finalized

## Already on vNext (from PR #206, merged earlier)

- D8 version picker — will deploy with this release via `docfx.yaml`
- Q/H method demos in README + examples
- `MidnightOf` internal DRY helper
- `PublicAPI.Shipped.txt` Q/H promote (metadata correction)
- Canonical CI sync, slnx refresh, `.gitignore` docfx api rule

## Post-merge

1. Tag `v1.3.1` and push — `release.yaml` validates, packs, publishes to
   NuGet, and triggers `docfx.yaml` to deploy versioned docs with the
   picker
2. Delete `vNext` branch
3. Verify NuGet 1.3.1 indexed (~5 min) and
   `chris-wolfgang.github.io/DateTime-Extensions/versions/v1.3.1/`
   resolves