### PR TITLE
README: drop ?branch=main from PR build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of extension methods for `DateTime` data type in .Net
 
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.DateTime.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.DateTime)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.DateTime.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.DateTime)
-[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/DateTime-Extensions/pr.yaml?branch=main&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/DateTime-Extensions/actions/workflows/pr.yaml)
+[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/DateTime-Extensions/pr.yaml?label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/DateTime-Extensions/actions/workflows/pr.yaml)
 [![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/DateTime-Extensions/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/DateTime-Extensions/actions/workflows/release.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)


### PR DESCRIPTION
## Summary

The PR build badge has been displaying "failing" because the badge URL
filtered on `?branch=main`, but `pr.yaml` only triggers on
`pull_request` events. Those runs are tagged with the **head** branch
(e.g. `vNext`, `feature/foo`), never `main`. The filter matched only
the rare PR whose head branch was literally named `main` — a March
2026 dependabot run that failed years ago — so the badge was stuck on
that stale result while every real PR build has been green.

Dropping the filter (`?label=...` instead of `?branch=main&label=...`)
lets the badge fall back to shields.io's default behavior: show the
latest run of the workflow, regardless of branch.

## Fleet follow-up

Same broken filter is almost certainly on every downstream README that
shares this badge pattern, plus repo-template itself. After this lands
the fix should be propagated via a small bulk-repo-pr fanout.