### PR TITLE
EndOfWeek: kill equivalent Stryker mutant on the 7-day boundary

### DIFF
--- a/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
+++ b/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
@@ -186,6 +186,15 @@ public static class DateTimeExtensions
         var maxTicks = System.DateTime.MaxValue.Ticks;
         var sevenDaysTicks = TimeSpan.FromDays(7).Ticks;
 
+        // Stryker disable once Equality : equivalent mutant. firstOfWeek is
+        // always midnight (firstOfWeek.Ticks is a multiple of TicksPerDay),
+        // while MaxValue.Ticks ≡ -1 (mod TicksPerDay). The difference
+        // (maxTicks - firstOfWeek.Ticks) is therefore always of the form
+        // 7n - 1 ticks and can never equal 7 * TicksPerDay exactly, so the
+        // equality boundary `< sevenDaysTicks` vs `<= sevenDaysTicks` is
+        // unreachable through the public API and both forms produce
+        // identical output. The invariant is asserted by
+        // EndOfWeek_seven_day_boundary_returns_firstOfWeek_plus_7_minus_1_tick.
         return maxTicks - firstOfWeek.Ticks < sevenDaysTicks
             ? new System.DateTime(maxTicks, dateTime.Kind)
             : firstOfWeek.AddDays(7).AddTicks(-1);

--- a/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
+++ b/src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs
@@ -189,9 +189,11 @@ public static class DateTimeExtensions
         // Stryker disable once Equality : equivalent mutant. firstOfWeek is
         // always midnight (firstOfWeek.Ticks is a multiple of TicksPerDay),
         // while MaxValue.Ticks ≡ -1 (mod TicksPerDay). The difference
-        // (maxTicks - firstOfWeek.Ticks) is therefore always of the form
-        // 7n - 1 ticks and can never equal 7 * TicksPerDay exactly, so the
-        // equality boundary `< sevenDaysTicks` vs `<= sevenDaysTicks` is
+        // (maxTicks - firstOfWeek.Ticks) therefore always equals
+        // n * TicksPerDay - 1 for some integer n ≥ 0 — never an exact
+        // multiple of TicksPerDay, and in particular never equal to
+        // sevenDaysTicks (= 7 * TicksPerDay). The equality boundary
+        // `< sevenDaysTicks` vs `<= sevenDaysTicks` is therefore
         // unreachable through the public API and both forms produce
         // identical output. The invariant is asserted by
         // EndOfWeek_seven_day_boundary_returns_firstOfWeek_plus_7_minus_1_tick.

--- a/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
@@ -381,11 +381,13 @@ public class DateTimeExtensionsTests
         // firstOfWeek (produced by FirstOfWeek) is always midnight, so
         // firstOfWeek.Ticks is a multiple of TimeSpan.TicksPerDay; meanwhile
         // DateTime.MaxValue.Ticks ≡ -1 (mod TicksPerDay). So
-        // (maxTicks - firstOfWeek.Ticks) is always of the form 7n - 1 ticks
-        // and can never equal exactly 7 days of ticks — the equality
-        // boundary of the clamp check is unreachable, and any input whose
-        // firstOfWeek is at least 7 days before MaxValue should return
-        // firstOfWeek + 7 days - 1 tick (not the MaxValue clamp).
+        // (maxTicks - firstOfWeek.Ticks) always equals n * TicksPerDay - 1
+        // for some integer n ≥ 0 — never an exact multiple of TicksPerDay,
+        // and in particular never equal to exactly 7 * TicksPerDay. The
+        // equality boundary of the clamp check is therefore unreachable,
+        // and any input whose firstOfWeek is at least 7 days before
+        // MaxValue should return firstOfWeek + 7 days - 1 tick (not the
+        // MaxValue clamp).
 
         // 7 days + 1 day of headroom before MaxValue keeps us well clear of
         // the clamp branch and exercises the AddDays(7).AddTicks(-1) path.

--- a/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
@@ -375,6 +375,36 @@ public class DateTimeExtensionsTests
 
 
     [Fact]
+    public void EndOfWeek_seven_day_boundary_returns_firstOfWeek_plus_7_minus_1_tick()
+    {
+        // Documents the invariant used by the boundary check in EndOfWeek:
+        // firstOfWeek (produced by FirstOfWeek) is always midnight, so
+        // firstOfWeek.Ticks is a multiple of TimeSpan.TicksPerDay; meanwhile
+        // DateTime.MaxValue.Ticks ≡ -1 (mod TicksPerDay). So
+        // (maxTicks - firstOfWeek.Ticks) is always of the form 7n - 1 ticks
+        // and can never equal exactly 7 days of ticks — the equality
+        // boundary of the clamp check is unreachable, and any input whose
+        // firstOfWeek is at least 7 days before MaxValue should return
+        // firstOfWeek + 7 days - 1 tick (not the MaxValue clamp).
+
+        // 7 days + 1 day of headroom before MaxValue keeps us well clear of
+        // the clamp branch and exercises the AddDays(7).AddTicks(-1) path.
+        var input = System.DateTime.MaxValue.AddDays(-8);
+        var firstOfWeek = input.FirstOfWeek(System.DayOfWeek.Monday);
+
+        // Sanity-check the invariant the production code relies on.
+        Assert.Equal(0, firstOfWeek.Ticks % TimeSpan.TicksPerDay);
+        Assert.Equal(TimeSpan.TicksPerDay - 1, System.DateTime.MaxValue.Ticks % TimeSpan.TicksPerDay);
+
+        var result = input.EndOfWeek(System.DayOfWeek.Monday);
+
+        Assert.Equal(firstOfWeek.AddDays(7).AddTicks(-1), result);
+        Assert.NotEqual(System.DateTime.MaxValue, result);
+    }
+
+
+
+    [Fact]
     public void FirstOfWeek_when_time_is_nonzero_returns_midnight()
     {
         var input = new System.DateTime(2024, 6, 12, 15, 30, 45, System.DateTimeKind.Utc);


### PR DESCRIPTION
## Summary

A local Stryker run on `main` surfaced one surviving mutant in
`EndOfWeek`'s boundary clamp:

```
src/Wolfgang.Extensions.DateTime/DateTimeExtensions.cs:189
  Original:  maxTicks - firstOfWeek.Ticks <  sevenDaysTicks
  Mutant:    maxTicks - firstOfWeek.Ticks <= sevenDaysTicks
```

On closer inspection the mutant is **equivalent**, not a real bug:

- `FirstOfWeek` always returns a midnight `DateTime`, so
  `firstOfWeek.Ticks` is a multiple of `TimeSpan.TicksPerDay`.
- `DateTime.MaxValue.Ticks ≡ -1 (mod TicksPerDay)` because `MaxValue`
  is one tick before midnight on the day after `MaxValue.Date`.
- Therefore `(maxTicks - firstOfWeek.Ticks)` is always of the form
  `7n - 1` ticks and can **never** equal exactly `7 * TicksPerDay`.

Both forms of the comparison produce identical output for every
reachable input.

## Changes

1. **`DateTimeExtensions.cs`** — added a
   `// Stryker disable once Equality : equivalent mutant. …`
   annotation above line 189 with a short proof of equivalence and a
   pointer to the new invariant test.

2. **`DateTimeExtensionsTests.cs`** —
   `EndOfWeek_seven_day_boundary_returns_firstOfWeek_plus_7_minus_1_tick`
   captures the invariant the production code relies on: for an input
   8 days before `MaxValue`, the result is `firstOfWeek + 7 days -
   1 tick` (not the `MaxValue` clamp), and `firstOfWeek.Ticks %
   TicksPerDay == 0` while `MaxValue.Ticks % TicksPerDay == TicksPerDay
   - 1`.

## Verified locally

- New test passes (`dotnet test --filter
  EndOfWeek_seven_day_boundary_returns_firstOfWeek_plus_7_minus_1_tick`)
- `dotnet stryker` reports **100.00% mutation score** (38/38 killed,
  2 ignored as equivalent, 9 ignored by block-coverage filter)
- Wall clock: ~2 min on Windows