### PR TITLE
build-pr.ps1: canonical sync — use 'tar -f -' for gitleaks stdin extract

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -302,7 +302,11 @@ if (-not $SkipSecurity) {
             # is on PATH by default on most Linux distros and macOS; if not, prepend it.
             $localBin = Join-Path $HOME ".local/bin"
             New-Item -ItemType Directory -Force -Path $localBin | Out-Null
-            curl -sSfL $url | tar xz -C $localBin gitleaks
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
             if (-not ($env:PATH -split [IO.Path]::PathSeparator | Where-Object { $_ -eq $localBin })) {
                 $env:PATH = "$localBin$([IO.Path]::PathSeparator)$env:PATH"
             }


### PR DESCRIPTION
## Summary

One-line canonical sync to `scripts/build-pr.ps1` picking up the
gitleaks-tar-stdin hang fix from `repo-template/main`. Unprotected
file; merges through `vNext` without admin bypass.

## Diff

```diff
-            curl -sSfL $url | tar xz -C $localBin gitleaks
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
```

## Why

GNU `tar` without `-f` defaults to `/dev/tape` (or the path in the
`TAPE` environment variable). In CI runners or any fresh shell where
that path doesn't exist, `curl ... | tar xz ...` can hang silently
because tar is waiting on a tape device that will never become
ready. Explicit `-f -` forces tar to read from stdin, which is the
intent of the pipe in the first place.

## Scope

Last canonical re-sync deferred this one (small, unprotected — best
routed via `vNext` rather than mixed in with the protected workflow
re-sync in PR #218). All other remaining DateTime ↔ repo-template
drift is either intentional per-repo content (docfx scaffolding,
real Introduction/Getting-Started prose, BannedSymbols.txt
placeholder-resolution) or cosmetic (release.yaml comment position,
pr.yaml redundant template-skip guards).