### PR TITLE
Benchmarks: update stale 'eight methods' XML doc to enumerate the current 14

### DIFF
--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
@@ -5,11 +5,17 @@ using Wolfgang.Extensions.DateTime;
 namespace Wolfgang.Extensions.DateTime.Benchmarks;
 
 /// <summary>
-/// Microbenchmarks for the public extension methods. All eight methods
-/// allocate a small number of DateTime structs and short loops; they should
-/// be well under a microsecond apiece. The MemoryDiagnoser is enabled so any
-/// future refactor that introduces allocation surfaces in the gh-pages
-/// benchmark chart immediately.
+/// Microbenchmarks for the public extension methods. Every public method
+/// on <see cref="DateTimeExtensions"/> has a corresponding [Benchmark]
+/// here — fourteen methods at present (<c>TruncateMilliseconds</c>,
+/// <c>TruncateSeconds</c>, <c>FirstOfMonth</c> / <c>EndOfMonth</c>,
+/// <c>FirstOfYear</c> / <c>EndOfYear</c>, <c>FirstOfQuarter</c> /
+/// <c>EndOfQuarter</c>, <c>FirstOfHalf</c> / <c>EndOfHalf</c>, plus
+/// both overloads of <c>FirstOfWeek</c> and <c>EndOfWeek</c>). They
+/// allocate a small number of DateTime structs and short loops; each
+/// should be well under a microsecond. The MemoryDiagnoser is enabled
+/// so any future refactor that introduces allocation surfaces in the
+/// gh-pages benchmark chart immediately.
 /// </summary>
 [MemoryDiagnoser]
 public class DateTimeExtensionsBenchmarks


### PR DESCRIPTION
## Summary

One-file XML-doc fix on `DateTimeExtensionsBenchmarks`. Stacked on `vNext`.

The class-level summary said *"All eight methods …"* — accurate when
the benchmark file was first written, but went stale in v1.3.0 (4
Quarter/Half methods added) and again when the
`FirstOfWeek_CurrentCulture` / `EndOfWeek_CurrentCulture` benchmarks
were split out for the culture-lookup overhead measurement (2 more).
Today the file carries one `[Benchmark]` per public method on
`DateTimeExtensions` — fourteen in total.

## Change

Reword the summary to:
- enumerate every method group by name (so a future reader doesn't
  have to count),
- replace the bare *"eight"* with an explicit *"fourteen methods at
  present"* and the parenthetical list,
- keep the rest of the rationale (MemoryDiagnoser, allocation budget,
  sub-microsecond target) unchanged.

## Coverage check

Confirmed 1:1 — every public extension method on `DateTimeExtensions`
has a corresponding `[Benchmark]` here.