### PR TITLE
docs/DOCFX-VERSION-PICKER.md: canonical sync from repo-template

### DIFF
--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -114,17 +114,35 @@ canonical version-selector UI.
 
 ## How it gets to gh-pages
 
+`docfx.yaml` is **not** triggered directly by `push` or by pushing a
+tag — it has only `workflow_call` (invoked by `release.yaml` after a
+GitHub Release is published) and `workflow_dispatch` (manual). Two
+paths reach it:
+
 ```
-push to main / release tag
-  └─ docfx.yaml fires
-       ├─ docfx build  → _site/  (includes public/version-picker.js,
-       │                          inline bootstrap in every page's
-       │                          footer via _appFooter)
-       ├─ Generate versions.json from v* tags → _site/versions.json
-       ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
-       └─ Generate root index.html from version-picker-template.html
-                  → deploy to gh-pages /
+Path 1 — normal: a GitHub Release is published
+  └─ release.yaml fires (on `release: types: [published]`)
+       └─ release.yaml → calls docfx.yaml as a reusable workflow
+            └─ docfx.yaml runs the deploy steps below
+
+Path 2 — manual: a maintainer runs docfx.yaml from the Actions tab
+  └─ docfx.yaml fires directly (on `workflow_dispatch`)
+       └─ docfx.yaml runs the deploy steps below
+
+The deploy steps that docfx.yaml runs in both cases:
+  ├─ docfx build  → _site/  (includes public/version-picker.js,
+  │                          inline bootstrap in every page's
+  │                          footer via _appFooter)
+  ├─ Generate versions.json from v* tags → _site/versions.json
+  ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+  └─ Generate root index.html from version-picker-template.html
+             → deploy to gh-pages /
 ```
+
+A plain `git push` to `main` does **not** redeploy the docs — the
+gh-pages content updates only via Path 1 (publishing a GitHub
+Release) or Path 2 (manually running `docfx.yaml` from the Actions
+tab).
 
 Result on gh-pages:
 


### PR DESCRIPTION
## Summary

Pulls `docs/DOCFX-VERSION-PICKER.md` verbatim from `repo-template/main`.
Unprotected file — merges through `vNext` without admin bypass.

## What changes

The old DateTime copy described the docs-deploy chain as:

```
push to main / release tag
  └─ docfx.yaml fires
```

That implied `docfx.yaml` is push-triggered, which is **wrong** —
`docfx.yaml` has only `workflow_call` (invoked by `release.yaml` after
a GitHub Release is published) and `workflow_dispatch` (manual). The
canonical version walks the two real paths explicitly:

```
Path 1 — normal: a GitHub Release is published
  └─ release.yaml fires (on `release: types: [published]`)
       └─ release.yaml → calls docfx.yaml as a reusable workflow
            └─ docfx.yaml runs the deploy steps below

Path 2 — manual: a maintainer runs docfx.yaml from the Actions tab
  └─ docfx.yaml fires directly (on `workflow_dispatch`)
       └─ docfx.yaml runs the deploy steps below
```

Same deploy steps in both cases (docfx build → `_site/` → push to
`gh-pages/versions/<v>/`). The fix is one section of prose with no
mechanism change.

## Why now

Last drift scan after PRs #218 + #219 left this as the one remaining
content drift worth syncing on DateTime-Extensions (the rest are
either cosmetic or intentional per-repo content). Closing it now
keeps the DateTime ↔ canonical drift surface at zero post-stack.