### PR TITLE
test: add DateTime.MinValue boundary tests for FirstOf{Month,Year,Quarter,Half}

### DIFF
--- a/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.DateTime.Tests.Unit/DateTimeExtensionsTests.cs
@@ -365,6 +365,46 @@ public class DateTimeExtensionsTests
 
 
     [Fact]
+    public void FirstOfMonth_when_DateTime_MinValue_does_not_throw()
+    {
+        var result = System.DateTime.MinValue.FirstOfMonth();
+
+        Assert.Equal(System.DateTime.MinValue.Ticks, result.Ticks);
+    }
+
+
+
+    [Fact]
+    public void FirstOfYear_when_DateTime_MinValue_does_not_throw()
+    {
+        var result = System.DateTime.MinValue.FirstOfYear();
+
+        Assert.Equal(System.DateTime.MinValue.Ticks, result.Ticks);
+    }
+
+
+
+    [Fact]
+    public void FirstOfQuarter_when_DateTime_MinValue_does_not_throw()
+    {
+        var result = System.DateTime.MinValue.FirstOfQuarter();
+
+        Assert.Equal(System.DateTime.MinValue.Ticks, result.Ticks);
+    }
+
+
+
+    [Fact]
+    public void FirstOfHalf_when_DateTime_MinValue_does_not_throw()
+    {
+        var result = System.DateTime.MinValue.FirstOfHalf();
+
+        Assert.Equal(System.DateTime.MinValue.Ticks, result.Ticks);
+    }
+
+
+
+    [Fact]
     public void EndOfWeek_when_DateTime_MaxValue_returns_max_ticks()
     {
         var result = System.DateTime.MaxValue.EndOfWeek(System.DayOfWeek.Monday);


### PR DESCRIPTION
## Summary

Adds `DateTime.MinValue`-roundtrip tests for `FirstOfMonth`, `FirstOfYear`, `FirstOfQuarter`, and `FirstOfHalf`, matching the shape of the existing `FirstOfWeek_when_DateTime_MinValue_does_not_throw` test.

These methods route through `MidnightOf(year, month, day, kind)`, which constructs a new `DateTime` from components. For `MinValue` (0001-01-01) they should return the value unchanged — previously only enforced for `FirstOfWeek`. This closes the asymmetry with the `EndOf*` methods, which all have an explicit `MaxValue` test.

## Changes

Test-only — no source changes.

- `FirstOfMonth_when_DateTime_MinValue_does_not_throw`
- `FirstOfYear_when_DateTime_MinValue_does_not_throw`
- `FirstOfQuarter_when_DateTime_MinValue_does_not_throw`
- `FirstOfHalf_when_DateTime_MinValue_does_not_throw`

## Verification

`dotnet test -c Release -f net10.0 --filter "FullyQualifiedName~when_DateTime_MinValue"` → 5 passed, 0 failed.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)