### PR TITLE
chore: salvage benchmark doc + build-pr.ps1 tar fix from vNext

### DIFF
--- a/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.DateTime.Benchmarks/DateTimeExtensionsBenchmarks.cs
@@ -5,11 +5,17 @@ using Wolfgang.Extensions.DateTime;
 namespace Wolfgang.Extensions.DateTime.Benchmarks;
 
 /// <summary>
-/// Microbenchmarks for the public extension methods. All eight methods
-/// allocate a small number of DateTime structs and short loops; they should
-/// be well under a microsecond apiece. The MemoryDiagnoser is enabled so any
-/// future refactor that introduces allocation surfaces in the gh-pages
-/// benchmark chart immediately.
+/// Microbenchmarks for the public extension methods. Every public method
+/// on <see cref="DateTimeExtensions"/> has a corresponding [Benchmark]
+/// here — fourteen methods at present (<c>TruncateMilliseconds</c>,
+/// <c>TruncateSeconds</c>, <c>FirstOfMonth</c> / <c>EndOfMonth</c>,
+/// <c>FirstOfYear</c> / <c>EndOfYear</c>, <c>FirstOfQuarter</c> /
+/// <c>EndOfQuarter</c>, <c>FirstOfHalf</c> / <c>EndOfHalf</c>, plus
+/// both overloads of <c>FirstOfWeek</c> and <c>EndOfWeek</c>). They
+/// allocate a small number of DateTime structs and short loops; each
+/// should be well under a microsecond. The MemoryDiagnoser is enabled
+/// so any future refactor that introduces allocation surfaces in the
+/// gh-pages benchmark chart immediately.
 /// </summary>
 [MemoryDiagnoser]
 public class DateTimeExtensionsBenchmarks

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -302,7 +302,11 @@ if (-not $SkipSecurity) {
             # is on PATH by default on most Linux distros and macOS; if not, prepend it.
             $localBin = Join-Path $HOME ".local/bin"
             New-Item -ItemType Directory -Force -Path $localBin | Out-Null
-            curl -sSfL $url | tar xz -C $localBin gitleaks
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
             if (-not ($env:PATH -split [IO.Path]::PathSeparator | Where-Object { $_ -eq $localBin })) {
                 $env:PATH = "$localBin$([IO.Path]::PathSeparator)$env:PATH"
             }


### PR DESCRIPTION
## Summary

Two non-source improvements landed on the `vNext` integration branch but never reached `main`. This PR brings them over so `vNext` can be retired until a real version is cut.

| File | Change | Origin |
|---|---|---|
| `benchmarks/…/DateTimeExtensionsBenchmarks.cs` | XML doc: stale "eight methods" → current 14 | #220 |
| `scripts/build-pr.ps1` | `tar -xz -f -` reads gitleaks archive from stdin (GNU tar without `-f` defaults to `/dev/tape`, can hang silently in CI) | #219 |

## Scope

Docs + CI script only — **no source or public-API change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)